### PR TITLE
Feat/#12 route basic

### DIFF
--- a/src/app/maptest/page.tsx
+++ b/src/app/maptest/page.tsx
@@ -3,7 +3,11 @@
 import { useState, useCallback } from 'react';
 import KakaoMap from '@/components/features/map/kakao-map';
 import Clusterer from '@/components/features/map/clusterer';
-import { KakaoMapInstance, MarkerOptions } from '@/types/kakao-map.type';
+import {
+  KakaoMapInstance,
+  MarkerOptions,
+  MarkerProps,
+} from '@/types/kakao-map.type';
 
 // 임시 장소 데이터
 const PLACES: MarkerOptions[] = [
@@ -27,10 +31,19 @@ const PLACES: MarkerOptions[] = [
 
 const MapPage = () => {
   const [map, setMap] = useState<KakaoMapInstance | null>(null);
-  const [markers, setMarkers] = useState<MarkerOptions[]>(PLACES);
+  const [markers, setMarkers] = useState<MarkerProps[]>(
+    PLACES.map((place) => ({
+      ...place,
+      onClick: () => handleMarkerClick(place.title),
+    })),
+  );
 
   const handleMapLoad = useCallback((mapInstance: KakaoMapInstance) => {
     setMap(mapInstance);
+  }, []);
+
+  const handleMarkerClick = useCallback((title: string) => {
+    console.log(`${title} 클릭!`);
   }, []);
 
   /**
@@ -42,6 +55,7 @@ const MapPage = () => {
       {
         position: { lat: 33.45 + prev.length * 0.01, lng: 126.57 },
         title: `테스트 마커 ${prev.length + 1}`,
+        onClick: () => handleMarkerClick(`테스트 마커 ${prev.length + 1}`),
       },
     ]);
   };

--- a/src/app/maptest/page.tsx
+++ b/src/app/maptest/page.tsx
@@ -67,14 +67,17 @@ const MapPage = () => {
    * 마커 추가 함수
    */
   const addMarker = () => {
-    setMarkers((prev) => [
-      ...prev,
-      {
-        position: { lat: 33.45 + prev.length * 0.01, lng: 126.57 },
-        title: `테스트 마커 ${prev.length + 1}`,
-        onClick: () => handleMarkerClick(`테스트 마커 ${prev.length + 1}`),
-      },
-    ]);
+    setMarkers((prev) => {
+      const newTitle = `테스트 마커 ${prev.length + 1}`;
+      return [
+        ...prev,
+        {
+          position: { lat: 33.45 + prev.length * 0.01, lng: 126.57 },
+          title: newTitle,
+          onClick: () => handleMarkerClick(newTitle),
+        },
+      ];
+    });
   };
 
   /**
@@ -91,7 +94,7 @@ const MapPage = () => {
     <div className="h-screen w-full">
       <KakaoMap
         center={{ lat: 33.45, lng: 126.57 }}
-        level={3}
+        level={5}
         onMapLoad={handleMapLoad}
       />
       {map && (

--- a/src/app/maptest/page.tsx
+++ b/src/app/maptest/page.tsx
@@ -3,6 +3,7 @@
 import { useState, useCallback } from 'react';
 import KakaoMap from '@/components/features/map/kakao-map';
 import Clusterer from '@/components/features/map/clusterer';
+import Polyline from '@/components/features/map/polyline';
 import {
   KakaoMapInstance,
   MarkerOptions,
@@ -10,22 +11,35 @@ import {
 } from '@/types/kakao-map.type';
 
 // 임시 장소 데이터
+// https://www.jejudatahub.net/data/view/data/TOURISM/674
 const PLACES: MarkerOptions[] = [
   {
-    position: { lat: 33.450701, lng: 126.570667 },
-    title: '성산일출봉',
+    position: { lat: 33.55121797, lng: 126.69361 },
+    title: '북촌포구 주차장',
   },
   {
-    position: { lat: 33.4996213, lng: 126.5311884 },
-    title: '우도',
+    position: { lat: 33.55098302, lng: 126.693698 },
+    title: '화장실',
   },
   {
-    position: { lat: 33.248485, lng: 126.570667 },
-    title: '한라산',
+    position: { lat: 33.55081597, lng: 126.693294 },
+    title: '오르막 경사로',
   },
   {
-    position: { lat: 33.450701, lng: 126.470667 },
-    title: '만장굴',
+    position: { lat: 33.54979296, lng: 126.692917 },
+    title: '주차장',
+  },
+  {
+    position: { lat: 33.54987402, lng: 126.692674 },
+    title: '내리막 경사로',
+  },
+  {
+    position: { lat: 33.54845404, lng: 126.686449 },
+    title: '오르막 경사로',
+  },
+  {
+    position: { lat: 33.54834801, lng: 126.686249 },
+    title: '내리막 경사로',
   },
 ];
 
@@ -37,6 +51,9 @@ const MapPage = () => {
       onClick: () => handleMarkerClick(place.title),
     })),
   );
+  const [polylines, setPolylines] = useState<
+    { path: { lat: number; lng: number }[] }[]
+  >([]);
 
   const handleMapLoad = useCallback((mapInstance: KakaoMapInstance) => {
     setMap(mapInstance);
@@ -60,6 +77,16 @@ const MapPage = () => {
     ]);
   };
 
+  /**
+   * Polyline 추가 함수
+   */
+  const addPolyline = () => {
+    setPolylines((prev) => [
+      ...prev,
+      { path: PLACES.map((place) => place.position) },
+    ]);
+  };
+
   return (
     <div className="h-screen w-full">
       <KakaoMap
@@ -67,7 +94,19 @@ const MapPage = () => {
         level={3}
         onMapLoad={handleMapLoad}
       />
-      {map && <Clusterer map={map} markers={markers} />}
+      {map && (
+        <>
+          <Clusterer map={map} markers={markers} />
+          <Polyline
+            map={map}
+            path={PLACES.map((place) => place.position)}
+            strokeWeight={5}
+            strokeColor="#4CAF50"
+            strokeOpacity={0.8}
+            strokeStyle="solid"
+          />
+        </>
+      )}
     </div>
   );
 };

--- a/src/components/features/map/clusterer.tsx
+++ b/src/components/features/map/clusterer.tsx
@@ -3,6 +3,31 @@
 import { useEffect, useRef } from 'react';
 import { ClustererInstance, ClustererOptions } from '@/types/kakao-map.type';
 
+/**
+ * 카카오맵 마커 클러스터링 컴포넌트
+ * @param ClustererOptions.map - 카카오맵 인스턴스
+ * @param ClustererOptions.markers - 클러스터링할 마커 배열
+ * @param ClustererOptions.options - 클러스터의 표시 옵션(ClustererOptions 타입 참고)
+ *
+ * @example
+ * ```tsx
+ * const MapWithClusters = () => {
+ *   const [map, setMap] = useState<KakaoMapInstance | null>(null);
+ *   const markers = [];
+ *
+ *   return (
+ *     <div className="h-[400px]">
+ *       <KakaoMap
+ *         center={{ lat: 33.450701, lng: 126.570667 }}
+ *         level={3}
+ *         onMapLoad={setMap}
+ *       />
+ *       {map && <Clusterer map={map} markers={markers} />}
+ *     </div>
+ *   );
+ * };
+ * ```
+ */
 const Clusterer = ({ map, markers, ...options }: ClustererOptions) => {
   const clustererInstance = useRef<ClustererInstance | null>(null);
 

--- a/src/components/features/map/clusterer.tsx
+++ b/src/components/features/map/clusterer.tsx
@@ -52,25 +52,36 @@ const Clusterer = ({ map, markers, ...options }: ClustererOptions) => {
   useEffect(() => {
     if (!map) return;
 
+    const kakaoMarkers = markers.map((marker) => {
+      const kakaoMarker = new window.kakao.maps.Marker({
+        position: new window.kakao.maps.LatLng(
+          marker.position.lat,
+          marker.position.lng,
+        ),
+        title: marker.title,
+        clickable: marker.clickable,
+        draggable: marker.draggable,
+      });
+
+      if (marker.onClick) {
+        window.kakao.maps.event.addListener(
+          kakaoMarker,
+          'click',
+          marker.onClick,
+        );
+      }
+
+      return kakaoMarker;
+    });
+
     // 새로운 클러스터러 생성
     const clusterer = new window.kakao.maps.MarkerClusterer({
       map,
-      markers: markers.map(
-        (marker) =>
-          new window.kakao.maps.Marker({
-            position: new window.kakao.maps.LatLng(
-              marker.position.lat,
-              marker.position.lng,
-            ),
-            title: marker.title,
-            clickable: marker.clickable,
-            draggable: marker.draggable,
-          }),
-      ),
+      markers: kakaoMarkers,
       gridSize: 60,
       minLevel: 6,
       minClusterSize: 2,
-      disableClickZoom: false,
+      disableClickZoom: true,
       styles,
       ...options,
     });

--- a/src/components/features/map/clusterer.tsx
+++ b/src/components/features/map/clusterer.tsx
@@ -79,7 +79,7 @@ const Clusterer = ({ map, markers, ...options }: ClustererOptions) => {
       map,
       markers: kakaoMarkers,
       gridSize: 60,
-      minLevel: 6,
+      minLevel: 5,
       minClusterSize: 2,
       disableClickZoom: true,
       styles,
@@ -90,7 +90,9 @@ const Clusterer = ({ map, markers, ...options }: ClustererOptions) => {
 
     return () => {
       if (clustererInstance.current) {
-        clustererInstance.current = {};
+        clustererInstance.current.setMap(null);
+        clustererInstance.current = null;
+        kakaoMarkers.forEach((marker) => marker.setMap(null));
       }
     };
   }, [map, markers, options]);

--- a/src/components/features/map/kakao-map.tsx
+++ b/src/components/features/map/kakao-map.tsx
@@ -9,6 +9,21 @@ import React from 'react';
  * @param KakaoMapProps.center - 지도의 중심 좌표 (위도, 경도)
  * @param KakaoMapProps.level - 지도의 확대 레벨
  * @param KakaoMapProps.onMapLoad - 지도 로드 완료 후 실행할 함수
+ *
+ * @example
+ * ```tsx
+ * const Map = () => {
+ *   return (
+ *     <div className="h-[400px]">
+ *       <KakaoMap
+ *         center={{ lat: 33.450701, lng: 126.570667 }}
+ *         level={3}
+ *         onMapLoad={setMap}
+ *       />
+ *     </div>
+ *   );
+ * };
+ * ```
  */
 const KakaoMap = ({ center, level, onMapLoad }: KakaoMapProps) => {
   const mapRef = useRef<HTMLDivElement>(null);

--- a/src/components/features/map/polyline.tsx
+++ b/src/components/features/map/polyline.tsx
@@ -1,0 +1,43 @@
+'use client';
+
+import { useEffect, useRef } from 'react';
+import { PolylineInstance, PolylineProps } from '@/types/kakao-map.type';
+
+const Polyline = ({ map, path, ...options }: PolylineProps) => {
+  const polylineInstance = useRef<PolylineInstance | null>(null);
+
+  // 경로 업데이트
+  useEffect(() => {
+    if (!map) return;
+
+    if (polylineInstance.current) {
+      polylineInstance.current.setMap(null);
+    }
+
+    const polyline = new window.kakao.maps.Polyline({
+      path: path.map(
+        (point) => new window.kakao.maps.LatLng(point.lat, point.lng),
+      ),
+      // default 스타일
+      strokeWeight: 3,
+      strokeColor: '#FF6B6B',
+      strokeOpacity: 0.8,
+      strokeStyle: 'solid',
+      ...options,
+    });
+
+    polyline.setMap(map);
+
+    polylineInstance.current = polyline;
+
+    return () => {
+      if (polylineInstance.current) {
+        polylineInstance.current.setMap(null);
+      }
+    };
+  }, [map, path, options]);
+
+  return null;
+};
+
+export default Polyline;

--- a/src/components/features/map/polyline.tsx
+++ b/src/components/features/map/polyline.tsx
@@ -10,10 +10,6 @@ const Polyline = ({ map, path, ...options }: PolylineProps) => {
   useEffect(() => {
     if (!map) return;
 
-    if (polylineInstance.current) {
-      polylineInstance.current.setMap(null);
-    }
-
     const polyline = new window.kakao.maps.Polyline({
       path: path.map(
         (point) => new window.kakao.maps.LatLng(point.lat, point.lng),
@@ -27,12 +23,12 @@ const Polyline = ({ map, path, ...options }: PolylineProps) => {
     });
 
     polyline.setMap(map);
-
     polylineInstance.current = polyline;
 
     return () => {
       if (polylineInstance.current) {
         polylineInstance.current.setMap(null);
+        polylineInstance.current = null;
       }
     };
   }, [map, path, options]);

--- a/src/components/features/map/polyline.tsx
+++ b/src/components/features/map/polyline.tsx
@@ -3,6 +3,38 @@
 import { useEffect, useRef } from 'react';
 import { PolylineInstance, PolylineProps } from '@/types/kakao-map.type';
 
+/**
+ * 카카오맵에 경로를 표시하는 컴포넌트
+ *
+ * @param PolylineProps.map - 카카오맵 인스턴스
+ * @param PolylineProps.path - 경로 좌표 배열
+ * @param PolylineProps.options - 경로 스타일 옵션(PolylineOptions 타입 참고)
+ *
+ * @example
+ * ```tsx
+ * const MapWithPolyline = () => {
+ *   const [map, setMap] = useState<KakaoMapInstance | null>(null);
+ *   const path = [];
+ *   const options = {
+ *     strokeWeight: 3,
+ *     strokeColor: '#4CAF50',
+ *     strokeOpacity: 0.8,
+ *     strokeStyle: 'solid'
+ *   };
+ *   return (
+ *     <div className="h-[400px]">
+ *       <KakaoMap
+ *         center={{ lat: 33.450701, lng: 126.570667 }}
+ *         level={3}
+ *         onMapLoad={setMap}
+ *       />
+ *       {map && <Polyline map={map} path={path} options={options} />}
+ *     </div>
+ *   );
+ * };
+ * ```
+ */
+
 const Polyline = ({ map, path, ...options }: PolylineProps) => {
   const polylineInstance = useRef<PolylineInstance | null>(null);
 
@@ -10,16 +42,19 @@ const Polyline = ({ map, path, ...options }: PolylineProps) => {
   useEffect(() => {
     if (!map) return;
 
-    const polyline = new window.kakao.maps.Polyline({
-      path: path.map(
-        (point) => new window.kakao.maps.LatLng(point.lat, point.lng),
-      ),
-      // default 스타일
+    const defaultOptions = {
       strokeWeight: 3,
       strokeColor: '#4CAF50',
       strokeOpacity: 0.8,
       strokeStyle: 'solid',
-      ...options,
+    };
+
+    const polyline = new window.kakao.maps.Polyline({
+      path: path.map(
+        (point) => new window.kakao.maps.LatLng(point.lat, point.lng),
+      ),
+      ...defaultOptions, // default 스타일
+      ...options, // 전달받은 옵션 우선
     });
 
     polyline.setMap(map);

--- a/src/components/features/map/polyline.tsx
+++ b/src/components/features/map/polyline.tsx
@@ -20,7 +20,7 @@ const Polyline = ({ map, path, ...options }: PolylineProps) => {
       ),
       // default 스타일
       strokeWeight: 3,
-      strokeColor: '#FF6B6B',
+      strokeColor: '#4CAF50',
       strokeOpacity: 0.8,
       strokeStyle: 'solid',
       ...options,

--- a/src/types/kakao-map.type.ts
+++ b/src/types/kakao-map.type.ts
@@ -44,7 +44,7 @@ export type MarkerProps = MarkerOptions & {
 
 export type ClustererOptions = {
   map: KakaoMapInstance;
-  markers: MarkerOptions[];
+  markers: MarkerProps[];
   gridSize?: number;
   minLevel?: number;
   minClusterSize?: number;

--- a/src/types/kakao-map.type.ts
+++ b/src/types/kakao-map.type.ts
@@ -45,10 +45,10 @@ export type MarkerProps = MarkerOptions & {
 export type ClustererOptions = {
   map: KakaoMapInstance;
   markers: MarkerProps[];
-  gridSize?: number;
-  minLevel?: number;
-  minClusterSize?: number;
-  disableClickZoom?: boolean;
+  gridSize?: number; // 클러스터의 격자 크기
+  minLevel?: number; // 클러스터가 표시될 최소 지도 레벨
+  minClusterSize?: number; // 클러스터가 생성될 최소 마커 수
+  disableClickZoom?: boolean; // 클러스터 클릭 시 줌 동작 비활성화 여부
   styles?: {
     width: string;
     height: string;

--- a/src/types/kakao-map.type.ts
+++ b/src/types/kakao-map.type.ts
@@ -61,3 +61,24 @@ export type ClustererOptions = {
 };
 
 export type ClustererInstance = {};
+
+export type PolylineOptions = {
+  path: {
+    lat: number;
+    lng: number;
+  }[];
+  strokeWeight?: number;
+  strokeColor?: string;
+  strokeOpacity?: number;
+  strokeStyle?: 'solid' | 'dot' | 'dash' | 'dashdot';
+};
+
+export type PolylineInstance = {
+  setMap(map: KakaoMapInstance | null): void;
+  setOptions(options: PolylineOptions): void;
+  setPath(path: { getLat(): number; getLng(): number }[]): void;
+};
+
+export type PolylineProps = PolylineOptions & {
+  map?: KakaoMapInstance;
+};

--- a/src/types/kakao-map.type.ts
+++ b/src/types/kakao-map.type.ts
@@ -60,7 +60,9 @@ export type ClustererOptions = {
   }[];
 };
 
-export type ClustererInstance = {};
+export type ClustererInstance = {
+  setMap(map: KakaoMapInstance | null): void;
+};
 
 export type PolylineOptions = {
   path: {


### PR DESCRIPTION
## 📝 설명

<!-- 이 PR에서 무엇을 변경했는지 간단히 설명해주세요. -->

이번 pr에서는 카카오맵 위에 경로 표시 및 스타일 커스터마이징 작업을 진행하였습니다.

## 🔗 관련 이슈

<!-- 이 PR이 해결하는 이슈 번호를 적어주세요. -->

- #12 

## 🔍 변경 사항

<!-- 주요 변경 사항을 목록으로 작성해주세요. -->

- 경로 컴포넌트 설계
- 단일/다중 경로 표시 기능 구현
- 경로 스타일 커스터마이징 가능하도록 props drilling 방식 사용

## ✅ 체크리스트

<!-- PR을 제출하기 전에 확인해야 할 항목들을 체크해주세요. -->

- [x] 코드가 프로젝트의 스타일 가이드를 준수합니다.
- [x] 모든 테스트가 통과했습니다.

## ℹ️ 추가 정보

<!-- 리뷰어가 알아야 할 추가 정보나 참고 자료가 있다면 여기에 작성해주세요. -->
참고문서: https://apis.map.kakao.com/web/documentation/#Polyline
현재 두께, 색상, 투명도, 선 스타일 커스터마이징 가능하게 하였습니다.
디폴트 스타일
strokeWeight: 3,
strokeColor: '#4CAF50',(녹색)
strokeOpacity: 0.8,
strokeStyle: 'solid',