### PR TITLE
Feat/#44 Type Camelize

### DIFF
--- a/src/lib/utils/camelize.ts
+++ b/src/lib/utils/camelize.ts
@@ -1,0 +1,47 @@
+import { CamelCaseObject } from '@/types/common.type';
+
+/**
+ * 스네이크 케이스 문자열을 카멜 케이스로 변환하는 유틸 함수
+ *
+ * @param str - 변환할 스네이크 케이스 문자열
+ * @returns 카멜 케이스로 변환된 문자열
+ */
+export const toCamelCase = (str: string): string =>
+  str.replace(/_([a-z])/g, (_, char: string) => char.toUpperCase());
+
+/**
+ * 객체의 모든 키를 스네이크 케이스에서 카멜 케이스로 재귀적으로 변환하는 함수
+ * 배열, 중첩 객체 등을 모두 처리합니다.
+ *
+ * @template T - 입력 객체의 타입
+ * @param obj - 변환할 객체, 배열 또는 원시값
+ * @returns 모든 키가 카멜 케이스로 변환된 객체
+ *
+ * @example
+ * camelize({ user_id: 1, created_at: '2023-01-01', nested_obj: { prop_name: 'value' } })
+ */
+export const camelize = <T>(obj: T): CamelCaseObject<T> => {
+  if (obj === null || obj === undefined) {
+    return obj as unknown as CamelCaseObject<T>;
+  }
+
+  if (Array.isArray(obj)) {
+    return obj.map((item) => camelize(item)) as unknown as CamelCaseObject<T>;
+  }
+
+  if (typeof obj !== 'object') {
+    return obj as CamelCaseObject<T>;
+  }
+
+  const result: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(obj)) {
+    const newKey = toCamelCase(key);
+    if (typeof value === 'object' && value !== null) {
+      result[newKey] = camelize(value);
+    } else {
+      result[newKey] = value;
+    }
+  }
+
+  return result as CamelCaseObject<T>;
+};

--- a/src/types/common.type.ts
+++ b/src/types/common.type.ts
@@ -1,0 +1,16 @@
+/** 문자열을 카멜 케이스로 변환하는 타입 */
+type CamelCase<S extends string> = S extends `${infer P}_${infer Q}`
+  ? `${P}${Capitalize<CamelCase<Q>>}`
+  : S;
+
+/** 객체의 모든 키를 카멜 케이스로 변환하는 타입 */
+export type CamelCaseObject<T> =
+  T extends Array<infer U>
+    ? Array<CamelCaseObject<U>>
+    : T extends object
+      ? {
+          [K in keyof T as CamelCase<
+            K extends string ? K : never
+          >]: CamelCaseObject<T[K]>;
+        }
+      : T;


### PR DESCRIPTION
## 📝 설명

타입을 카멜 케이스로 변환하는 함수를 추가했습니다.

<br>

## 🔗 관련 이슈

- #44

<br>

## ✅ 체크리스트

- [x] 코드가 프로젝트의 스타일 가이드를 준수합니다.
- [x] 모든 테스트가 통과했습니다.

<br>

## ℹ️ 추가 정보

api 함수 안에서 마지막에 아래와 같은 방식으로 사용하시면 됩니다. `data`는 supabase 통신으로 받아온 데이터입니다.
``` typescript
const camelizedData = data ? camelize(data) : null;
return camelizedData 
```
### 변경 전
![image](https://github.com/user-attachments/assets/586e6013-90a1-4bac-bd09-a00e236cb3e3)

### 변경 후
![image](https://github.com/user-attachments/assets/b67fc49f-dbbe-417b-97bf-ec51a55b82d9)

