### PR TITLE
Feat/#37 profile page

### DIFF
--- a/src/app/(mypage)/account/_components/account-personal-info.tsx
+++ b/src/app/(mypage)/account/_components/account-personal-info.tsx
@@ -105,11 +105,14 @@ const PersonalInfo = ({
         </Label>
         {isEditMode ? (
           <div className="flex flex-col">
-            <Input id="phone" placeholder={`${phone}`} {...register('phone')} />
+            <Input
+              id="phone"
+              placeholder={`${phone}`}
+              {...register('phone')}
+              className={PERSONAL_INFO_STYLE.input}
+            />
             {errors.phone && (
-              <p className="regular-14 m-2 text-destructive">
-                {errors.phone.message}
-              </p>
+              <p className="regular-14 m-2 text-red">{errors.phone.message}</p>
             )}
           </div>
         ) : (

--- a/src/app/(mypage)/account/_components/account-profile-info.tsx
+++ b/src/app/(mypage)/account/_components/account-profile-info.tsx
@@ -125,7 +125,7 @@ const ProfileInfo = ({
               className={PROFILE_INFO_STYLE.input}
             />
             {errors.nickname && (
-              <p className="regular-14 absolute m-2 text-destructive">
+              <p className="regular-14 absolute m-2 text-red">
                 {errors.nickname.message}
               </p>
             )}

--- a/src/app/(mypage)/account/_components/account-security-info.tsx
+++ b/src/app/(mypage)/account/_components/account-security-info.tsx
@@ -3,11 +3,10 @@
 import PasswordInput from '@/components/features/auth/auth-password-input';
 import { Button } from '@/components/ui/button';
 import { Label } from '@/components/ui/label';
-import { ERROR_MESSAGES as FORM_ERROR_MESSAGE } from '@/constants/auth.constants';
-import { ERROR_MESSAGES as UPDATE_ERROR_MESSAGE } from '@/constants/mypage.constants';
+import { ERROR_MESSAGES } from '@/constants/mypage.constants';
 import { fetchUpdatePassword } from '@/lib/apis/profile/update-profile.api';
 import useProviderFromCookie from '@/lib/hooks/use-get-provider';
-import { passwordSchema } from '@/lib/schemas/auth-schema';
+import { changePasswordSchema } from '@/lib/schemas/change-password-schema';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { useState } from 'react';
 import { useForm } from 'react-hook-form';
@@ -29,22 +28,6 @@ const SECURITY_INFO_STYLE = {
 const SecurityInfo = ({ userId }: { userId: string }) => {
   const [isEditMode, setIsEditMode] = useState<boolean>(false);
   const provider = useProviderFromCookie(userId);
-
-  // 비밀번호 스키마 정의
-  const changePasswordSchema = z
-    .object({
-      password: z.string(),
-      newPassword: passwordSchema,
-      confirmNewPassword: z.string(),
-    })
-    .refine((data) => data.newPassword === data.confirmNewPassword, {
-      message: FORM_ERROR_MESSAGE.PASSWORD_MISMATCH,
-      path: ['confirmNewPassword'],
-    })
-    .refine((data) => data.password !== '', {
-      message: FORM_ERROR_MESSAGE.REQUIRED_PASSWORD,
-      path: ['password'],
-    });
 
   type passwordValues = z.infer<typeof changePasswordSchema>;
 
@@ -84,7 +67,7 @@ const SecurityInfo = ({ userId }: { userId: string }) => {
       const result = await fetchUpdatePassword(data.password, data.newPassword);
       alert(result.message);
     } catch (error: unknown) {
-      let errorMessage = UPDATE_ERROR_MESSAGE.PASSWORD_UPDATE_FAILED;
+      let errorMessage = ERROR_MESSAGES.PASSWORD_UPDATE_FAILED;
       if (error instanceof Error) {
         errorMessage = error.message;
       }

--- a/src/app/(mypage)/account/_components/account-security-info.tsx
+++ b/src/app/(mypage)/account/_components/account-security-info.tsx
@@ -3,7 +3,9 @@
 import PasswordInput from '@/components/features/auth/auth-password-input';
 import { Button } from '@/components/ui/button';
 import { Label } from '@/components/ui/label';
-import { ERROR_MESSAGES } from '@/constants/auth.constants';
+import { ERROR_MESSAGES as FORM_ERROR_MESSAGE } from '@/constants/auth.constants';
+import { ERROR_MESSAGES as UPDATE_ERROR_MESSAGE } from '@/constants/mypage.constants';
+import { fetchUpdatePassword } from '@/lib/apis/profile/update-profile.api';
 import useProviderFromCookie from '@/lib/hooks/use-get-provider';
 import { passwordSchema } from '@/lib/schemas/auth-schema';
 import { zodResolver } from '@hookform/resolvers/zod';
@@ -36,11 +38,11 @@ const SecurityInfo = ({ userId }: { userId: string }) => {
       confirmNewPassword: z.string(),
     })
     .refine((data) => data.newPassword === data.confirmNewPassword, {
-      message: ERROR_MESSAGES.PASSWORD_MISMATCH,
+      message: FORM_ERROR_MESSAGE.PASSWORD_MISMATCH,
       path: ['confirmNewPassword'],
     })
     .refine((data) => data.password !== '', {
-      message: ERROR_MESSAGES.REQUIRED_PASSWORD,
+      message: FORM_ERROR_MESSAGE.REQUIRED_PASSWORD,
       path: ['password'],
     });
 
@@ -73,11 +75,24 @@ const SecurityInfo = ({ userId }: { userId: string }) => {
   };
 
   /** 비밀번호 수정 완료 버튼 클릭 핸들러  */
-  const handleEditCompleteButtonClick = (data: passwordValues) => {
+  const handleEditCompleteButtonClick = async (data: passwordValues) => {
     const isConfirmed = confirm('비밀번호를 수정하시겠습니까?');
     if (!isConfirmed) return;
-    // 비밀번호 번호 수정 로직
-    setIsEditMode(false);
+
+    // 비밀번호 번호 수정
+    try {
+      const result = await fetchUpdatePassword(data.password, data.newPassword);
+      alert(result.message);
+    } catch (error: unknown) {
+      let errorMessage = UPDATE_ERROR_MESSAGE.PASSWORD_UPDATE_FAILED;
+      if (error instanceof Error) {
+        errorMessage = error.message;
+      }
+      alert(errorMessage);
+    } finally {
+      setIsEditMode(false);
+      reset();
+    }
   };
 
   return (

--- a/src/app/(mypage)/account/_components/account-security-info.tsx
+++ b/src/app/(mypage)/account/_components/account-security-info.tsx
@@ -1,18 +1,26 @@
 'use client';
 
+import PasswordInput from '@/components/features/auth/auth-password-input';
 import { Button } from '@/components/ui/button';
-import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
+import { ERROR_MESSAGES } from '@/constants/auth.constants';
 import useProviderFromCookie from '@/lib/hooks/use-get-provider';
+import { passwordSchema } from '@/lib/schemas/auth-schema';
+import { zodResolver } from '@hookform/resolvers/zod';
 import { useState } from 'react';
+import { useForm } from 'react-hook-form';
+import { z } from 'zod';
 
-// TODO - rowLabel에 하드코딩된 width 바꾸기
 const SECURITY_INFO_STYLE = {
-  imageSize: 88,
-  invisibleBox: 'invisible w-[88px]',
-  title: 'my-3 text-lg font-semibold col-span-4 w-full',
-  rowLabel: 'text-md whitespace-nowrap font-normal w-[110px]',
-  rowValue: 'whitespace-nowrap',
+  container:
+    'px-8 py-6 rounded-24 bg-white border-gray-100 border border-gray-100',
+  invisibleBox: 'invisible w-[120px]',
+  title: 'semibold-18 col-span-4 w-full',
+  input:
+    'rounded-[12px] border border-gray-200 px-4 py-[10px] !placeholder-gray-200',
+  rowLabel: 'medium-16 text-[16px] whitespace-nowrap w-[107px] p-[10px]',
+  rowValue: 'whitespace-nowrap medium-16 p-[10px]',
+  button: 'medium-16 bg-transparent text-secondary-300 hover:bg-gray-100',
 };
 
 /** 회원정보 수정 페이지의 보안 섹션 컴포넌트 */
@@ -20,13 +28,52 @@ const SecurityInfo = ({ userId }: { userId: string }) => {
   const [isEditMode, setIsEditMode] = useState<boolean>(false);
   const provider = useProviderFromCookie(userId);
 
+  // 비밀번호 스키마 정의
+  const changePasswordSchema = z
+    .object({
+      password: z.string(),
+      newPassword: passwordSchema,
+      confirmNewPassword: z.string(),
+    })
+    .refine((data) => data.newPassword === data.confirmNewPassword, {
+      message: ERROR_MESSAGES.PASSWORD_MISMATCH,
+      path: ['confirmNewPassword'],
+    })
+    .refine((data) => data.password !== '', {
+      message: ERROR_MESSAGES.REQUIRED_PASSWORD,
+      path: ['password'],
+    });
+
+  type passwordValues = z.infer<typeof changePasswordSchema>;
+
+  const {
+    register,
+    handleSubmit,
+    formState: { errors, isValid },
+    reset,
+  } = useForm<passwordValues>({
+    resolver: zodResolver(changePasswordSchema),
+    defaultValues: {
+      password: '',
+      newPassword: '',
+      confirmNewPassword: '',
+    },
+    mode: 'onChange',
+  });
+
   /** 비밀번호 수정 버튼 클릭 핸들러 */
   const handleEditButtonClick = () => {
     setIsEditMode(true);
   };
 
+  /** 수정 취소 버튼 클릭 핸들러 */
+  const handleEditCancelButtonClick = () => {
+    setIsEditMode(false);
+    reset();
+  };
+
   /** 비밀번호 수정 완료 버튼 클릭 핸들러  */
-  const handleEditCompleteButtonClick = () => {
+  const handleEditCompleteButtonClick = (data: passwordValues) => {
     const isConfirmed = confirm('비밀번호를 수정하시겠습니까?');
     if (!isConfirmed) return;
     // 비밀번호 번호 수정 로직
@@ -34,10 +81,15 @@ const SecurityInfo = ({ userId }: { userId: string }) => {
   };
 
   return (
-    <div className="m-1 grid grid-cols-[auto_auto_1fr_auto] items-center gap-3">
+    <div
+      className={`m-1 grid grid-cols-[auto_auto_1fr_auto] gap-3 ${SECURITY_INFO_STYLE.container}`}
+    >
       <h3 className={SECURITY_INFO_STYLE.title}>보안</h3>
       {isEditMode ? (
-        <>
+        <form
+          className="contents"
+          onSubmit={handleSubmit(handleEditCompleteButtonClick)}
+        >
           <div className={SECURITY_INFO_STYLE.invisibleBox} />
           <Label
             htmlFor="currentPassword"
@@ -45,16 +97,35 @@ const SecurityInfo = ({ userId }: { userId: string }) => {
           >
             현재 비밀번호
           </Label>
-          <Input id="currentPassword" placeholder="********" />
+          <div className="flex flex-col">
+            <PasswordInput
+              id="currentPassword"
+              placeholder="********"
+              register={register('password')}
+            />
+            {errors.password && (
+              <p className="regular-14 m-2 text-red">
+                {errors.password.message}
+              </p>
+            )}
+          </div>
           <div className="invisible" />
           <div className="invisible" />
           <Label htmlFor="newPassword" className={SECURITY_INFO_STYLE.rowLabel}>
             새 비밀번호
           </Label>
-          <Input
-            id="newPassword"
-            placeholder="숫자, 문자, 특수문자를 포함하여 8자 이상"
-          />
+          <div className="flex flex-col">
+            <PasswordInput
+              id="newPassword"
+              placeholder="숫자, 문자, 특수문자를 포함하여 8자 이상"
+              register={register('newPassword')}
+            />
+            {errors.newPassword && (
+              <p className="regular-14 m-2 text-red">
+                {errors.newPassword.message}
+              </p>
+            )}
+          </div>
           <div className="invisible" />
           <div className="invisible" />
           <Label
@@ -63,21 +134,48 @@ const SecurityInfo = ({ userId }: { userId: string }) => {
           >
             새 비밀번호 확인
           </Label>
-          <Input
-            id="newPasswordCheck"
-            placeholder="숫자, 문자, 특수문자를 포함하여 8자 이상"
-          />
-          <Button onClick={handleEditCompleteButtonClick}>완료</Button>
-        </>
+          <div className="flex flex-col">
+            <PasswordInput
+              id="newPasswordCheck"
+              placeholder="숫자, 문자, 특수문자를 포함하여 8자 이상"
+              register={register('confirmNewPassword')}
+            />
+            {errors.confirmNewPassword && (
+              <p className="regular-14 m-2 text-red">
+                {errors.confirmNewPassword.message}
+              </p>
+            )}
+          </div>
+          <div>
+            <Button
+              type="submit"
+              className={SECURITY_INFO_STYLE.button}
+              disabled={!isValid}
+            >
+              완료
+            </Button>
+            <Button
+              className={SECURITY_INFO_STYLE.button}
+              onClick={handleEditCancelButtonClick}
+            >
+              취소
+            </Button>
+          </div>
+        </form>
       ) : (
         <>
           <div className={SECURITY_INFO_STYLE.invisibleBox} />
           <div className={SECURITY_INFO_STYLE.rowLabel}>현재 비밀번호</div>
-          <div>********</div>
+          <div className={SECURITY_INFO_STYLE.rowValue}>********</div>
           {provider !== 'email' ? (
             <div className="invisible" />
           ) : (
-            <Button onClick={handleEditButtonClick}>수정</Button>
+            <Button
+              className={SECURITY_INFO_STYLE.button}
+              onClick={handleEditButtonClick}
+            >
+              수정
+            </Button>
           )}
         </>
       )}

--- a/src/app/(mypage)/account/page.tsx
+++ b/src/app/(mypage)/account/page.tsx
@@ -12,8 +12,8 @@ const AccountPage = async () => {
 
   return (
     <div className="flex w-full flex-col gap-9">
+      <h2 className="semibold-28 w-full">회원정보 수정</h2>
       <Suspense fallback={<Loading />}>
-        <h2 className="semibold-28 w-full">회원정보 수정</h2>
         <ProfileInfo
           userId={user.id}
           nickname={user.nickname}

--- a/src/components/features/auth/auth-password-input.tsx
+++ b/src/components/features/auth/auth-password-input.tsx
@@ -18,6 +18,7 @@ const PasswordInput = ({
   placeholder,
   required = false,
   register,
+  className,
 }: PasswordInputProps) => {
   const [showPassword, setShowPassword] = useState(false);
 
@@ -29,7 +30,7 @@ const PasswordInput = ({
         id={id}
         type={showPassword ? 'text' : 'password'}
         placeholder={placeholder}
-        className="pr-10"
+        className={`pr-10 ${className}`}
         required={required}
         {...register}
       />

--- a/src/constants/mypage.constants.ts
+++ b/src/constants/mypage.constants.ts
@@ -10,12 +10,15 @@ export const ERROR_MESSAGES = {
   PHONE_UPDATE_FAILED: '휴대폰 번호 변경 중 오류가 발생했습니다.',
   PHONE_DATA_MISSING: '휴대폰 번호 데이터가 전달되지 않았습니다.',
   PHONE_DUPLICATE: '이미 사용중인 번호입니다.',
+  PASSWORD_UPDATE_FAILED: '비밀번호 변경 중 오류가 발생했습니다.',
+  PASSWORD_INVALID: '현재 비밀번호가 올바르지 않습니다.',
 };
 
 export const SUCCESS_MESSAGES = {
-  NICKNAME_UPDATED: '닉네임이 성공적으로 변경되었습니다.',
-  PROFILE_UPDATED: '프로필 이미지가 성공적으로 변경되었습니다.',
-  PHONE_UPDATED: '휴대폰 번호가 성공적으로 변경되었습니다.',
+  NICKNAME_UPDATED: '닉네임이 변경되었습니다.',
+  PROFILE_UPDATED: '프로필 이미지가 변경되었습니다.',
+  PHONE_UPDATED: '휴대폰 번호가 변경되었습니다.',
+  PASSWORD_UPDATED: '비밀번호가 변경되었습니다.',
 };
 
 export const MAX_FILE_SIZE = 5 * 1024 * 1024;

--- a/src/lib/schemas/auth-schema.ts
+++ b/src/lib/schemas/auth-schema.ts
@@ -17,7 +17,7 @@ const emailSchema = z
 /**
  * 비밀번호 유효성 검사를 위한 스키마
  */
-const passwordSchema = z
+export const passwordSchema = z
   .string()
   .min(1, { message: ERROR_MESSAGES.REQUIRED_PASSWORD })
   .min(VALIDATION_RULES.PASSWORD.MIN, {

--- a/src/lib/schemas/change-password-schema.ts
+++ b/src/lib/schemas/change-password-schema.ts
@@ -1,0 +1,19 @@
+import { z } from 'zod';
+import { passwordSchema } from './auth-schema';
+import { ERROR_MESSAGES } from '@/constants/auth.constants';
+
+// 비밀번호 스키마 정의
+export const changePasswordSchema = z
+  .object({
+    password: z.string(),
+    newPassword: passwordSchema,
+    confirmNewPassword: z.string(),
+  })
+  .refine((data) => data.newPassword === data.confirmNewPassword, {
+    message: ERROR_MESSAGES.PASSWORD_MISMATCH,
+    path: ['confirmNewPassword'],
+  })
+  .refine((data) => data.password !== '', {
+    message: ERROR_MESSAGES.REQUIRED_PASSWORD,
+    path: ['password'],
+  });

--- a/src/types/auth.type.ts
+++ b/src/types/auth.type.ts
@@ -63,6 +63,7 @@ export type PasswordInputProps = {
   id: string;
   placeholder: string;
   required?: boolean;
+  className?: string;
   /** react-hook-form의 register 반환값 */
   register: UseFormRegisterReturn;
 };


### PR DESCRIPTION
## 📝 설명

<!-- 이 PR에서 무엇을 변경했는지 간단히 설명해주세요. -->

프로필 페이지의 비밀번호 변경 기능을 구현하였습니다.

<br>

## 🔗 관련 이슈

<!-- 이 PR이 해결하는 이슈 번호를 적어주세요. -->

- #37

<br>

## 🔍 변경 사항

<!-- 주요 변경 사항을 목록으로 작성해주세요. -->

- 비밀번호 변경 서버 액션 추가
- 비밀번호 스키마 활용

<br>

## ✅ 체크리스트

<!-- PR을 제출하기 전에 확인해야 할 항목들을 체크해주세요. -->

- [x] 코드가 프로젝트의 스타일 가이드를 준수합니다.
- [x] 모든 테스트가 통과했습니다.

<br>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced account security with improved password management, including structured validation, error handling, and a cancel option.
  - Added new error and success messages related to password operations.

- **Style**
  - Updated input field designs across account pages, with refined error message styling for phone number and nickname updates.
  - Enabled dynamic styling for password inputs, ensuring a more consistent and user-friendly interface.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->