### PR TITLE
Feat/#137 password change modal

### DIFF
--- a/src/app/(auth)/reset-password/page.tsx
+++ b/src/app/(auth)/reset-password/page.tsx
@@ -7,10 +7,14 @@ import { Label } from '@/components/ui/label';
 import { Button } from '@/components/ui/button';
 import AuthErrorMessage from '@/components/features/auth/auth-error-message';
 import PasswordInput from '@/components/features/auth/auth-password-input';
+import ResetPasswordSuccessModal from '@/components/commons/reset-password-success-modal';
 
 import useResetPassword from '@/lib/hooks/use-reset-password';
 import { AUTH_BUTTON_TEXT } from '@/constants/auth.constants';
 
+/**
+ * 비밀번호 재설정 페이지 컴포넌트
+ */
 const ResetPasswordPage = () => {
   const {
     isSubmitted,
@@ -23,37 +27,6 @@ const ResetPasswordPage = () => {
     handlePasswordUpdate,
     redirectToHome,
   } = useResetPassword();
-
-  // 비밀번호 변경 성공 화면
-  if (isSubmitted) {
-    return (
-      <AuthLayout>
-        <div className="flex items-center justify-center p-6">
-          <div className="w-full">
-            <div className="mb-4 text-center">
-              <h2 className="bold-22">비밀번호 재설정</h2>
-            </div>
-            <div className="rounded-md bg-white">
-              <div className="text-center">
-                <div className="mx-auto mb-4 flex h-16 w-16 items-center justify-center rounded-md bg-gray-100">
-                  {/* 성공 아이콘 */}
-                </div>
-                <h3 className="mb-2 font-bold">
-                  비밀번호가 성공적으로 재설정되었습니다.
-                </h3>
-                <p className="mb-6 text-sm text-gray-500">
-                  {countdown}초 후 메인페이지로 돌아갑니다.
-                </p>
-                <Button className="w-full" onClick={redirectToHome}>
-                  홈으로 돌아가기
-                </Button>
-              </div>
-            </div>
-          </div>
-        </div>
-      </AuthLayout>
-    );
-  }
 
   return (
     <AuthLayout>
@@ -107,6 +80,13 @@ const ResetPasswordPage = () => {
           </Button>
         </form>
       </CardContent>
+
+      {/* 성공 모달 컴포넌트 */}
+      <ResetPasswordSuccessModal
+        open={isSubmitted}
+        countdown={countdown}
+        redirectToHome={redirectToHome}
+      />
     </AuthLayout>
   );
 };

--- a/src/components/commons/reset-password-success-modal.tsx
+++ b/src/components/commons/reset-password-success-modal.tsx
@@ -39,7 +39,7 @@ const ResetPasswordSuccessModal = ({
           />
 
           <p className="semibold-20 text-center text-secondary-300">
-            비밀번호 재설정이 성공적으로
+            비밀번호가 성공적으로
             <br />
             재설정되었습니다.
           </p>

--- a/src/components/commons/reset-password-success-modal.tsx
+++ b/src/components/commons/reset-password-success-modal.tsx
@@ -1,0 +1,57 @@
+'use client';
+
+import Image from 'next/image';
+import { Dialog, DialogContent } from '@/components/ui/no-close-button-dialog';
+import { useEffect } from 'react';
+import { ResetPasswordSuccessModalProps } from '@/types/auth.type';
+
+const ResetPasswordSuccessModal = ({
+  open,
+  countdown,
+  redirectToHome,
+}: ResetPasswordSuccessModalProps) => {
+  useEffect(() => {
+    if (!open) return;
+
+    if (countdown === 0) {
+      redirectToHome();
+    }
+  }, [countdown, open, redirectToHome]);
+
+  return (
+    <>
+      {/* CSS 선택자를 통해 이 모달의 닫기 버튼만 숨김 */}
+      <style jsx global>{`
+        .reset-password-success-modal [aria-label='Close'] {
+          display: none !important;
+        }
+      `}</style>
+
+      <Dialog open={open} onOpenChange={() => {}}>
+        <DialogContent className="reset-password-success-modal flex flex-col items-center justify-center p-6 sm:max-w-xs">
+          <Image
+            src="/character/happy_color.svg"
+            alt="성공 캐릭터"
+            width={100}
+            height={100}
+            className="mb-4"
+            priority
+          />
+
+          <p className="semibold-20 text-center text-secondary-300">
+            비밀번호 재설정이 성공적으로
+            <br />
+            재설정되었습니다.
+          </p>
+
+          <p className="medium-16 mt-3 text-center text-black">
+            {countdown}초 후<br />
+            메인 페이지로 이동됩니다.
+          </p>
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+};
+
+export default ResetPasswordSuccessModal;

--- a/src/components/ui/no-close-button-dialog.tsx
+++ b/src/components/ui/no-close-button-dialog.tsx
@@ -1,0 +1,117 @@
+'use client';
+
+import * as React from 'react';
+import * as DialogPrimitive from '@radix-ui/react-dialog';
+
+import { cn } from '@/lib/utils';
+
+const Dialog = DialogPrimitive.Root;
+
+const DialogTrigger = DialogPrimitive.Trigger;
+
+const DialogPortal = DialogPrimitive.Portal;
+
+const DialogClose = DialogPrimitive.Close;
+
+const DialogOverlay = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Overlay>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Overlay>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Overlay
+    ref={ref}
+    className={cn(
+      'fixed inset-0 z-50 bg-black/80 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0',
+      className,
+    )}
+    {...props}
+  />
+));
+DialogOverlay.displayName = DialogPrimitive.Overlay.displayName;
+
+const DialogContent = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content>
+>(({ className, children, ...props }, ref) => (
+  <DialogPortal>
+    <DialogOverlay />
+    <DialogPrimitive.Content
+      ref={ref}
+      className={cn(
+        'fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 rounded-12 bg-white p-6 shadow-[1px_1px_8px_1px_rgba(213,187,169,0.20)] outline-none duration-200 focus:outline-none focus-visible:outline-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%]',
+        className,
+      )}
+      {...props}
+    >
+      {children}
+    </DialogPrimitive.Content>
+  </DialogPortal>
+));
+DialogContent.displayName = DialogPrimitive.Content.displayName;
+
+const DialogHeader = ({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) => (
+  <div
+    className={cn(
+      'flex flex-col space-y-1.5 text-center sm:text-left',
+      className,
+    )}
+    {...props}
+  />
+);
+DialogHeader.displayName = 'DialogHeader';
+
+const DialogFooter = ({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) => (
+  <div
+    className={cn(
+      'flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2',
+      className,
+    )}
+    {...props}
+  />
+);
+DialogFooter.displayName = 'DialogFooter';
+
+const DialogTitle = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Title>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Title>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Title
+    ref={ref}
+    className={cn(
+      'text-lg font-semibold leading-none tracking-tight',
+      className,
+    )}
+    {...props}
+  />
+));
+DialogTitle.displayName = DialogPrimitive.Title.displayName;
+
+const DialogDescription = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Description>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Description>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Description
+    ref={ref}
+    className={cn('text-sm text-muted-foreground', className)}
+    {...props}
+  />
+));
+DialogDescription.displayName = DialogPrimitive.Description.displayName;
+
+export {
+  Dialog,
+  DialogPortal,
+  DialogOverlay,
+  DialogTrigger,
+  DialogClose,
+  DialogContent,
+  DialogHeader,
+  DialogFooter,
+  DialogTitle,
+  DialogDescription,
+};

--- a/src/types/auth.type.ts
+++ b/src/types/auth.type.ts
@@ -130,3 +130,12 @@ export type AuthErrorMessageProps = {
   className?: string;
   variant?: 'default' | 'destructive';
 };
+
+/**
+ * 비밀번호 재설정 성공 모달 컴포넌트 Props
+ */
+export type ResetPasswordSuccessModalProps = {
+  open: boolean;
+  countdown: number;
+  redirectToHome: () => void;
+};


### PR DESCRIPTION
## 📝 설명

<!-- 이 PR에서 무엇을 변경했는지 간단히 설명해주세요. -->

비밀번호 변경시 모달창

이 PR은 [기능 추가/버그 수정/문서 개선 등]을 위해 작성되었습니다.

## 🔗 관련 이슈

<!-- 이 PR이 해결하는 이슈 번호를 적어주세요. -->

- #137

## 🔍 변경 사항

<!-- 주요 변경 사항을 목록으로 작성해주세요. -->

- 모달창에 사용할 shadcn ui dialog 커스텀 마이징 하여 새파일 추가
- shad cn ui dialog를 이용하여 모달창 생성
- 기존의 비밀번호 변경시 ui가 변경되던 로직을 모달 컴포넌트로 이동

## ✅ 체크리스트

<!-- PR을 제출하기 전에 확인해야 할 항목들을 체크해주세요. -->

- [ ] 코드가 프로젝트의 스타일 가이드를 준수합니다.
- [ ] 모든 테스트가 통과했습니다.

## ℹ️ 추가 정보

<!-- 리뷰어가 알아야 할 추가 정보나 참고 자료가 있다면 여기에 작성해주세요. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a modal dialog to display password reset success, including a countdown and automatic redirection to the main page.
- **Refactor**
  - Updated password reset flow to use the new modal for success messages, improving user experience.
- **Style**
  - Enhanced modal appearance with custom styling and removed the close button for a streamlined look.
- **Documentation**
  - Added descriptive comments for new components and props.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->