### PR TITLE
Feat/#152 plan detail layout

### DIFF
--- a/src/app/plan-detail/[planId]/page.tsx
+++ b/src/app/plan-detail/[planId]/page.tsx
@@ -1,39 +1,89 @@
+import Image from 'next/image';
 import { fetchGetCurrentUser } from '@/lib/apis/auth/auth-server.api';
 import { fetchGetPlanById } from '@/lib/apis/plan/plan.api';
 import ErrorMessage from '@/components/features/alert/error-message';
+import PlanForm from '@/app/plan-detail/_components/plan-form';
+import { fetchGetPlanDaysAndLocations } from '@/lib/apis/plan/plan.api';
+import NotFound from '../not-found';
 
 const PlanDetailPage = async ({ params }: { params: { planId: string } }) => {
-  const { user } = await fetchGetCurrentUser();
-  const userId = user?.id;
-
-  if (!userId) {
-    return (
-      <ErrorMessage
-        title="로그인 필요"
-        description="일정을 보려면 로그인이 필요합니다."
-      />
-    );
-  }
+  const HAPPY_IMAGE = {
+    width: 37,
+    height: 36,
+  };
 
   try {
+    // 먼저 일정 정보를 가져옵니다.
     const plan = await fetchGetPlanById(Number(params.planId));
+
+    // 현재 로그인한 사용자 정보를 가져옵니다.
+    const { user } = await fetchGetCurrentUser();
+    const userId = user?.id;
+
+    // 비공개 일정인 경우 로그인 필수
+    if (!plan.public) {
+      // 로그인하지 않은 경우
+      if (!userId) {
+        return <NotFound />;
+      }
+      // 작성자가 아닌 경우
+      if (plan.userId !== userId) {
+        return <NotFound />;
+      }
+    }
+
+    // 공개 일정이지만 로그인하지 않은 경우
+    if (!userId) {
+      return (
+        <ErrorMessage
+          title="로그인 필요"
+          description="일정을 보려면 로그인이 필요합니다."
+        />
+      );
+    }
+
+    const dayPlaces = await fetchGetPlanDaysAndLocations(Number(params.planId));
+
+    const initialPlan = {
+      planId: plan.planId,
+      userId: plan.userId,
+      title: plan.title,
+      description: plan.description,
+      travelStartDate: plan.travelStartDate,
+      travelEndDate: plan.travelEndDate,
+      planImg: plan.planImg,
+      public: plan.public,
+    };
+
+    const isOwner = plan.userId === userId;
 
     return (
       <div className="flex flex-col">
-        <span className="text-28 font-bold">일정 보기</span>
-        <div className="mt-4">
-          <h2 className="text-24 font-semibold">{plan.title}</h2>
-          <p className="mt-2 text-gray-600">{plan.description}</p>
+        <div className="border-b px-9">
+          {/* 헤더 영역 */}
+          <div className="flex gap-3 pt-6">
+            <span className="text-28 font-bold leading-[130%]">
+              {isOwner ? '내 일정 수정하기' : '일정 보기'}
+            </span>
+            <Image
+              src="/character/happy_color.svg"
+              alt="happy icon"
+              width={HAPPY_IMAGE.width}
+              height={HAPPY_IMAGE.height}
+            />
+          </div>
+          <PlanForm
+            userId={userId}
+            initialPlan={initialPlan}
+            initialDayPlaces={dayPlaces}
+            isReadOnly={!isOwner}
+          />
         </div>
       </div>
     );
   } catch (error) {
-    return (
-      <ErrorMessage
-        title="일정 조회 실패"
-        description="일정을 불러오는데 실패했습니다. 다시 시도해주세요."
-      />
-    );
+    // 일정을 찾을 수 없는 경우
+    return <NotFound />;
   }
 };
 

--- a/src/app/plan-detail/[planId]/page.tsx
+++ b/src/app/plan-detail/[planId]/page.tsx
@@ -1,4 +1,5 @@
 import { fetchGetCurrentUser } from '@/lib/apis/auth/auth-server.api';
+import { fetchGetPlanById } from '@/lib/apis/plan/plan.api';
 import ErrorMessage from '@/components/features/alert/error-message';
 
 const PlanDetailPage = async ({ params }: { params: { planId: string } }) => {
@@ -14,11 +15,26 @@ const PlanDetailPage = async ({ params }: { params: { planId: string } }) => {
     );
   }
 
-  return (
-    <div className="flex flex-col">
-      <span className="text-28 font-bold">일정 보기</span>
-    </div>
-  );
+  try {
+    const plan = await fetchGetPlanById(Number(params.planId));
+
+    return (
+      <div className="flex flex-col">
+        <span className="text-28 font-bold">일정 보기</span>
+        <div className="mt-4">
+          <h2 className="text-24 font-semibold">{plan.title}</h2>
+          <p className="mt-2 text-gray-600">{plan.description}</p>
+        </div>
+      </div>
+    );
+  } catch (error) {
+    return (
+      <ErrorMessage
+        title="일정 조회 실패"
+        description="일정을 불러오는데 실패했습니다. 다시 시도해주세요."
+      />
+    );
+  }
 };
 
 export default PlanDetailPage;

--- a/src/app/plan-detail/[planId]/page.tsx
+++ b/src/app/plan-detail/[planId]/page.tsx
@@ -1,7 +1,24 @@
-const PlanDetailPage = ({ params }: { params: { planId: string } }) => {
-  const planId = parseInt(params.planId);
+import { fetchGetCurrentUser } from '@/lib/apis/auth/auth-server.api';
+import ErrorMessage from '@/components/features/alert/error-message';
 
-  return <div>MyPlanPage</div>;
+const PlanDetailPage = async ({ params }: { params: { planId: string } }) => {
+  const { user } = await fetchGetCurrentUser();
+  const userId = user?.id;
+
+  if (!userId) {
+    return (
+      <ErrorMessage
+        title="로그인 필요"
+        description="일정을 보려면 로그인이 필요합니다."
+      />
+    );
+  }
+
+  return (
+    <div className="flex flex-col">
+      <span className="text-28 font-bold">일정 보기</span>
+    </div>
+  );
 };
 
 export default PlanDetailPage;

--- a/src/app/plan-detail/_components/place-card.tsx
+++ b/src/app/plan-detail/_components/place-card.tsx
@@ -50,6 +50,7 @@ const PlaceCard = ({
   imageUrl,
   isLastItem = false,
   onDelete,
+  isReadOnly = false,
 }: {
   index: number;
   dayNumber: number;
@@ -61,13 +62,19 @@ const PlaceCard = ({
   imageUrl?: string;
   isLastItem?: boolean;
   onDelete?: () => void;
+  isReadOnly?: boolean;
 }) => {
   const dayColorSet = dayNumber % 2 === 1 ? COLORS.ODD : COLORS.EVEN;
   const defaultImage = useMemo(() => getRandomDefaultImage(), []);
   const displayImageUrl = imageUrl || defaultImage;
 
   return (
-    <div className="flex w-full cursor-grab gap-3 active:cursor-grabbing">
+    <div
+      className={cn(
+        'flex w-full gap-3',
+        !isReadOnly && 'cursor-grab active:cursor-grabbing',
+      )}
+    >
       {/* 원형으로 인덱스 표시 */}
       <div
         className={`regular-12 flex h-6 w-6 flex-col items-center justify-center gap-[10px] rounded-[12px] ${dayColorSet.bg} px-2 text-white`}
@@ -145,14 +152,16 @@ const PlaceCard = ({
         </div>
 
         {/* 삭제 버튼 */}
-        <button className="shrink-0 self-start p-1" onClick={onDelete}>
-          <Image
-            src="/icons/close.svg"
-            alt="삭제"
-            width={BUTTON_SIZE.width}
-            height={BUTTON_SIZE.height}
-          />
-        </button>
+        {!isReadOnly && onDelete && (
+          <button className="shrink-0 self-start p-1" onClick={onDelete}>
+            <Image
+              src="/icons/close.svg"
+              alt="삭제"
+              width={BUTTON_SIZE.width}
+              height={BUTTON_SIZE.height}
+            />
+          </button>
+        )}
       </div>
     </div>
   );

--- a/src/app/plan-detail/_components/plan-form.tsx
+++ b/src/app/plan-detail/_components/plan-form.tsx
@@ -7,29 +7,46 @@ import PlanSchedule from './plan-schedule';
 import { Plan } from '@/types/plan.type';
 import { DayPlaces, TabType } from '@/types/plan-detail.type';
 
-const PlanForm = ({ userId }: { userId: string }) => {
-  const [startDate, setStartDate] = useState<Date | null>(null);
-  const [endDate, setEndDate] = useState<Date | null>(null);
+const PlanForm = ({
+  userId,
+  initialPlan,
+  initialDayPlaces,
+  isReadOnly = false,
+}: {
+  userId: string;
+  initialPlan?: Omit<Plan, 'nickname' | 'createdAt' | 'publicAt' | 'isLiked'>;
+  initialDayPlaces?: DayPlaces;
+  isReadOnly?: boolean;
+}) => {
+  const [startDate, setStartDate] = useState<Date | null>(
+    initialPlan?.travelStartDate ? new Date(initialPlan.travelStartDate) : null,
+  );
+  const [endDate, setEndDate] = useState<Date | null>(
+    initialPlan?.travelEndDate ? new Date(initialPlan.travelEndDate) : null,
+  );
   const [plan, setPlan] = useState<
     Omit<Plan, 'nickname' | 'createdAt' | 'publicAt' | 'isLiked'>
-  >({
-    planId: 0,
-    planImg: '',
-    title: '',
-    description: '',
-    travelStartDate: '',
-    travelEndDate: '',
-    userId: userId,
-    public: false,
-  });
+  >(
+    initialPlan || {
+      planId: 0,
+      planImg: '',
+      title: '',
+      description: '',
+      travelStartDate: '',
+      travelEndDate: '',
+      userId: userId,
+      public: false,
+    },
+  );
   const [isCalendarOpen, setIsCalendarOpen] = useState(false);
-  const [dayPlaces, setDayPlaces] = useState<DayPlaces>({});
+  const [dayPlaces, setDayPlaces] = useState<DayPlaces>(initialDayPlaces || {});
   const [activeTab, setActiveTab] = useState<TabType>('전체보기');
   const [routeSummary, setRouteSummary] = useState<{
     [key: number]: { distance: number; duration: number }[];
   }>({});
 
   const handleDateChange = (dates: [Date | null, Date | null]) => {
+    if (isReadOnly) return;
     const [start, end] = dates;
     setStartDate(start);
     setEndDate(end);
@@ -52,13 +69,18 @@ const PlanForm = ({ userId }: { userId: string }) => {
         setIsCalendarOpen={setIsCalendarOpen}
         handleDateChange={handleDateChange}
         planTitle={plan.title}
-        setPlanTitle={(title) => setPlan((prev) => ({ ...prev, title }))}
+        setPlanTitle={(title) =>
+          !isReadOnly && setPlan((prev) => ({ ...prev, title }))
+        }
         planDescription={plan.description || ''}
         setPlanDescription={(description) =>
-          setPlan((prev) => ({ ...prev, description }))
+          !isReadOnly && setPlan((prev) => ({ ...prev, description }))
         }
         planImage={plan.planImg || ''}
-        setPlanImage={(planImg) => setPlan((prev) => ({ ...prev, planImg }))}
+        setPlanImage={(planImg) =>
+          !isReadOnly && setPlan((prev) => ({ ...prev, planImg }))
+        }
+        isReadOnly={isReadOnly}
       />
       <PlanMap
         dayPlaces={dayPlaces}
@@ -77,6 +99,7 @@ const PlanForm = ({ userId }: { userId: string }) => {
         activeTab={activeTab}
         setActiveTab={setActiveTab}
         routeSummary={routeSummary}
+        isReadOnly={isReadOnly}
       />
     </div>
   );

--- a/src/app/plan-detail/_components/plan-header.tsx
+++ b/src/app/plan-detail/_components/plan-header.tsx
@@ -27,6 +27,7 @@ const PlanHeader = ({
   setPlanDescription,
   planImage,
   setPlanImage,
+  isReadOnly,
 }: {
   startDate: Date | null;
   endDate: Date | null;
@@ -39,6 +40,7 @@ const PlanHeader = ({
   setPlanDescription: (description: string) => void;
   planImage: string | null;
   setPlanImage: (image: string | null) => void;
+  isReadOnly?: boolean;
 }) => {
   const [isUploading, setIsUploading] = useState(false);
   const { successToast } = useCustomToast();
@@ -104,10 +106,9 @@ const PlanHeader = ({
             accept="image/*"
             className="hidden px-[58px] py-7"
             onChange={handleFileChange}
-            disabled={isUploading}
+            disabled={isUploading || isReadOnly}
           />
           {planImage ? (
-            // <div className="relative aspect-video w-full bg-gray-200">
             <Image
               src={planImage}
               alt="썸네일"
@@ -116,13 +117,12 @@ const PlanHeader = ({
               className="object-contain"
             />
           ) : (
-            // </div>
             <div className="flex h-full w-full flex-col items-center justify-center gap-3">
               <p className="text-24 text-gray-300">+</p>
               <p className="text-center text-14 font-medium text-gray-300">
-                내 일정을 대표할
-                <br />
-                이미지를 추가하세요
+                {isReadOnly
+                  ? '등록된 이미지가 없습니다'
+                  : '내 일정을 대표할\n이미지를 추가하세요'}
               </p>
             </div>
           )}
@@ -150,6 +150,7 @@ const PlanHeader = ({
                 value={planTitle}
                 onChange={(e) => setPlanTitle(e.target.value)}
                 className="w-full resize-none border-0 bg-transparent py-5 pl-12 text-14 focus-visible:ring-0 focus-visible:ring-offset-0"
+                readOnly={isReadOnly}
               />
             </div>
           </div>
@@ -161,7 +162,10 @@ const PlanHeader = ({
                 type="button"
                 variant="outline"
                 className="h-7 w-fit justify-start border-transparent bg-gray-50 px-5 py-1 text-left text-14 font-normal hover:bg-gray-100"
-                onClick={() => setIsCalendarOpen(!isCalendarOpen)}
+                onClick={() =>
+                  !isReadOnly && setIsCalendarOpen(!isCalendarOpen)
+                }
+                disabled={isReadOnly}
               >
                 {formatTravelPeriod(startDate, endDate)}
               </Button>
@@ -200,6 +204,7 @@ const PlanHeader = ({
             onChange={(e) => setPlanDescription(e.target.value)}
             maxLength={500}
             className="h-[160px] w-full resize-none rounded-[12px] border-gray-200 py-5 pl-12 text-14 focus-visible:ring-0 focus-visible:ring-offset-0"
+            readOnly={isReadOnly}
           />
         </div>
       </div>

--- a/src/app/plan-detail/not-found.tsx
+++ b/src/app/plan-detail/not-found.tsx
@@ -1,0 +1,29 @@
+import Image from 'next/image';
+import Link from 'next/link';
+import { Button } from '@/components/ui/button';
+
+export default function NotFound() {
+  return (
+    <div className="flex min-h-[calc(100vh-80px)] flex-col items-center justify-center gap-6">
+      <Image
+        src="/character/sad.svg"
+        alt="sad character"
+        width={120}
+        height={120}
+      />
+      <div className="flex flex-col items-center gap-2">
+        <h2 className="text-24 font-bold">존재하지 않는 일정이에요</h2>
+        <p className="text-16 text-gray-500">
+          비공개 일정이거나 삭제된 일정일 수 있어요
+        </p>
+      </div>
+      <Link href="/">
+        <Button className="flex items-center gap-2 rounded-[20px] border border-primary-500 bg-white px-3 py-2 hover:bg-primary-100">
+          <span className="text-center text-16 font-medium leading-[150%] text-primary-500">
+            홈으로 돌아가기
+          </span>
+        </Button>
+      </Link>
+    </div>
+  );
+}

--- a/src/lib/apis/plan/plan.api.ts
+++ b/src/lib/apis/plan/plan.api.ts
@@ -346,3 +346,41 @@ export const fetchUploadPlanImage = async (
 
   return publicUrl;
 };
+
+export const fetchGetPlanById = async (planId: number): Promise<Plan> => {
+  const supabase = await getServerClient();
+
+  const { data, error } = await supabase
+    .from('plans')
+    .select(
+      `
+      plan_id,
+      user_id,
+      title,
+      description,
+      travel_start_date,
+      travel_end_date,
+      plan_img,
+      public,
+      created_at,
+      public_at,
+      users:user_id (
+        nickname
+      )
+    `,
+    )
+    .eq('plan_id', planId)
+    .single();
+
+  if (error) {
+    throw new Error('일정을 불러오는데 실패했습니다.');
+  }
+
+  const camelizedData = camelize(data);
+
+  return {
+    ...camelizedData,
+    nickname: camelizedData.users.nickname,
+    isLiked: false, // TODO: 좋아요 여부 확인 로직 추가
+  };
+};

--- a/src/types/plan.type.ts
+++ b/src/types/plan.type.ts
@@ -11,6 +11,25 @@ export type UsersRow = Pick<
 // PlansRow를 CamelCase로 변환한 타입
 export type Plan = CamelCaseObject<PlansRow & UsersRow & { is_liked: boolean }>;
 
+export type PlanWithDays = Plan & {
+  days: {
+    dayId: number;
+    day: number;
+    locations: {
+      visitOrder: number;
+      places: {
+        placeId: number;
+        name: string;
+        address: string;
+        latitude: number;
+        longitude: number;
+        category: string;
+        imageUrl: string | null;
+      };
+    }[];
+  }[];
+};
+
 // 플랜 카드에서 쓰는 타입 (좋아요 포함)
 export type PlanCardType = {
   planId: number;


### PR DESCRIPTION
## 📝 설명

<!-- 이 PR에서 무엇을 변경했는지 간단히 설명해주세요. -->

이 pr에서는 일정 상세 페이지 구현 및 사용자 권한에 따라 일정 상세 페이지를 보여주는 작업을 진행하였습니다.

## 🔗 관련 이슈

<!-- 이 PR이 해결하는 이슈 번호를 적어주세요. -->

- #152 

## 🔍 변경 사항

<!-- 주요 변경 사항을 목록으로 작성해주세요. -->

- 페이지 라우팅 구현
  - plan-detail/[planId] 경로 설정
  - 동적 라우팅 파라미터 처리
- 권한 체크 로직 구현
  - 작성자 여부 확인
  - 공개 여부 확인

- 일정 데이터 조회 API 연동
  - 일정 기본 정보 조회
  -  일정 장소 목록 조회
- 권한 체크 API 연동
  - 작성자 여부 확인 API
  - 공개 여부 확인 API
- 에러 처리
  - 권한 없는 사용자 접근 시 처리
  - 비공개 일정 접근 시 처리
- 작성자일 경우에만 수정 버튼 표시

## ✅ 체크리스트

<!-- PR을 제출하기 전에 확인해야 할 항목들을 체크해주세요. -->

- [x] 코드가 프로젝트의 스타일 가이드를 준수합니다.
- [x] 모든 테스트가 통과했습니다.

## ℹ️ 추가 정보

<!-- 리뷰어가 알아야 할 추가 정보나 참고 자료가 있다면 여기에 작성해주세요. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a detailed plan view page that displays comprehensive schedule information, including day-by-day locations and plan metadata.
  - Added a read-only mode for plan details, disabling editing features for users without edit permissions.
  - Implemented a custom "Not Found" page for inaccessible or deleted plans, with a user-friendly message and navigation back to the homepage.

- **Enhancements**
  - Improved the plan form and schedule components to support initial data loading and conditional interactivity based on user permissions.

- **Bug Fixes**
  - Enhanced error handling when fetching plan data, ensuring users see appropriate feedback if data retrieval fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->