### PR TITLE
Hotfix/#152 plan detail route

### DIFF
--- a/src/app/my-plan/_components/plan-filter-section.tsx
+++ b/src/app/my-plan/_components/plan-filter-section.tsx
@@ -25,6 +25,7 @@ import { useRouter } from 'next/navigation';
 import Image from 'next/image';
 import PlanHorizontalCard from '@/components/features/card/plan-horizontal_card';
 import { useQueryClient } from '@tanstack/react-query';
+import { useToast } from '@/hooks/use-toast';
 
 /**
  * 여행 계획 필터 섹션 컴포넌트
@@ -52,6 +53,7 @@ const PlanFilterSection = ({
   userNickname: string;
 }) => {
   const router = useRouter();
+  const { toast } = useToast();
   const [isOpen, setIsOpen] = useState(false);
   const [filter, setFilter] = useState<FilterState>({
     type: FILTER_TYPES.PUBLIC,
@@ -126,10 +128,18 @@ const PlanFilterSection = ({
           queryClient.invalidateQueries({
             queryKey: ['filteredPlans', userId],
           });
+          toast({
+            title: '일정 삭제 완료',
+            description: '일정이 성공적으로 삭제되었습니다.',
+          });
         },
         onError: (error) => {
           console.error('일정 삭제 실패:', error);
-          alert('일정 삭제에 실패했습니다. 다시 시도해주세요.');
+          toast({
+            title: '일정 삭제 실패',
+            description: '일정 삭제에 실패했습니다. 다시 시도해주세요.',
+            variant: 'destructive',
+          });
         },
       });
     }

--- a/src/app/plan-detail/_components/day-select-required-modal.tsx
+++ b/src/app/plan-detail/_components/day-select-required-modal.tsx
@@ -20,10 +20,6 @@ const DaySelectRequiredModal = ({
         text: '확인',
         onClick: onClose,
       }}
-      secondaryButton={{
-        text: '확인',
-        onClick: onClose,
-      }}
     />
   );
 };

--- a/src/app/plan-detail/_components/plan-schedule.tsx
+++ b/src/app/plan-detail/_components/plan-schedule.tsx
@@ -21,8 +21,7 @@ import ScheduleSaveModal from './schedule-save-modal';
 import { fetchSavePlan, fetchSavePlanPlaces } from '@/lib/apis/plan/plan.api';
 import PlanCardModal from '@/components/features/plan/plan-card-modal';
 import ScheduleCreatedModal from './schedule-created-modal';
-import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
-import { AlertCircle } from 'lucide-react';
+import { useToast } from '@/hooks/use-toast';
 import Image from 'next/image';
 
 const BASE_TAB_STYLE =
@@ -88,6 +87,7 @@ const PlanSchedule = ({
   };
   isReadOnly?: boolean;
 }) => {
+  const { toast } = useToast();
   const dayCount = calculateTotalDays(startDate, endDate);
   const [placeCount, setPlaceCount] = useState(0);
   const [copiedDay, setCopiedDay] = useState<number | null>(null);
@@ -95,21 +95,6 @@ const PlanSchedule = ({
   const [dayToDelete, setDayToDelete] = useState<number | null>(null);
   const [isSaveModalOpen, setIsSaveModalOpen] = useState(false);
   const [isPublicModalOpen, setIsPublicModalOpen] = useState(false);
-  const [alert, setAlert] = useState<{
-    title: string;
-    description: string;
-  } | null>(null);
-
-  // Alert를 자동으로 제거하는 useEffect 추가
-  useEffect(() => {
-    if (alert) {
-      const timer = setTimeout(() => {
-        setAlert(null);
-      }, 3000); // 3초 후에 Alert 제거
-
-      return () => clearTimeout(timer);
-    }
-  }, [alert]);
 
   /**
    * 장소 추가 핸들러
@@ -299,34 +284,38 @@ const PlanSchedule = ({
 
   const handleSaveButtonClick = () => {
     if (!planTitle) {
-      setAlert({
+      toast({
         title: '일정 제목 누락',
         description: '일정 제목을 입력해주세요.',
+        variant: 'destructive',
       });
       return;
     }
 
     if (!startDate || !endDate) {
-      setAlert({
+      toast({
         title: '여행 기간 누락',
         description: '여행 기간을 선택해주세요.',
+        variant: 'destructive',
       });
       return;
     }
 
     if (startDate > endDate) {
-      setAlert({
+      toast({
         title: '여행 기간 오류',
         description: '여행 종료일은 시작일보다 이후여야 합니다.',
+        variant: 'destructive',
       });
       return;
     }
 
     // 일정 일자 데이터가 없는 경우
     if (Object.keys(dayPlaces).length === 0) {
-      setAlert({
+      toast({
         title: '일정 데이터 누락',
         description: '일정에 최소 하나 이상의 장소를 추가해주세요.',
+        variant: 'destructive',
       });
       return;
     }
@@ -356,11 +345,16 @@ const PlanSchedule = ({
       await fetchSavePlanPlaces(planId, dayPlaces);
 
       setIsPublicModalOpen(false);
+      toast({
+        title: '일정 저장 완료',
+        description: '일정이 성공적으로 저장되었습니다.',
+      });
     } catch (error) {
       console.error('일정 공개 설정 실패:', error);
-      setAlert({
+      toast({
         title: '일정 저장 실패',
         description: '일정 공개 설정에 실패했습니다.',
+        variant: 'destructive',
       });
     }
   };
@@ -386,11 +380,16 @@ const PlanSchedule = ({
       await fetchSavePlanPlaces(planId, dayPlaces);
 
       setIsPublicModalOpen(false);
+      toast({
+        title: '일정 저장 완료',
+        description: '일정이 성공적으로 저장되었습니다.',
+      });
     } catch (error) {
       console.error('일정 비공개 설정 실패:', error);
-      setAlert({
+      toast({
         title: '일정 저장 실패',
         description: '일정 비공개 설정에 실패했습니다.',
+        variant: 'destructive',
       });
     }
   };
@@ -417,18 +416,6 @@ const PlanSchedule = ({
 
   return (
     <div className="relative min-h-screen pb-32">
-      {alert && (
-        <Alert
-          variant={alert.title.includes('실패') ? 'destructive' : 'default'}
-          className="text-red-500 border-red-500 fixed bottom-4 left-4 z-50 w-auto animate-in fade-in slide-in-from-bottom-4"
-        >
-          <AlertCircle className="text-red-500 h-4 w-4" />
-          <AlertTitle className="text-red-500">{alert.title}</AlertTitle>
-          <AlertDescription className="text-red-500">
-            {alert.description}
-          </AlertDescription>
-        </Alert>
-      )}
       <DragDropContext
         onDragEnd={(result) => !isReadOnly && handleDragEnd(result)}
       >

--- a/src/components/features/card/plan-horizontal_card.tsx
+++ b/src/components/features/card/plan-horizontal_card.tsx
@@ -35,9 +35,9 @@ const PlanHorizontalCard = ({
   onDelete,
 }: PlanHorizontalCardProps) => {
   return (
-    <Link href={`/plan-detail/${plan.planId}`} className="flex gap-4">
+    <div className="flex gap-4">
       {/* 이미지 영역 */}
-      <div className="relative">
+      <Link href={`/plan-detail/${plan.planId}`} className="relative">
         <div className={`relative ${CARD.imageSize}`}>
           <PlanImage
             image={plan.planImg}
@@ -50,7 +50,7 @@ const PlanHorizontalCard = ({
           isLiked={plan.isLiked}
           className="absolute right-4 top-4"
         />
-      </div>
+      </Link>
 
       {/* 컨텐츠 영역 */}
       <div className="flex flex-1 flex-col gap-2">
@@ -77,7 +77,10 @@ const PlanHorizontalCard = ({
         </div>
 
         {/* 닉네임 및 날짜 영역 */}
-        <div className="medium-12 flex items-center gap-2 text-gray-500">
+        <Link
+          href={`/plan-detail/${plan.planId}`}
+          className="medium-12 flex items-center gap-2 text-gray-500"
+        >
           <span className="whitespace-nowrap">{plan.nickname}</span>
           <Separator orientation="vertical" className="h-[11px] bg-gray-300" />
           <Duration
@@ -85,14 +88,22 @@ const PlanHorizontalCard = ({
             end={plan.travelEndDate}
             separator="-"
           />
-        </div>
+        </Link>
         {/* 제목 및 description 영역 */}
-        <p className="medium-16 line-clamp-1">{plan.title}</p>
-        <p className="regular-14 line-clamp-2 text-description">
+        <Link
+          href={`/plan-detail/${plan.planId}`}
+          className="medium-16 line-clamp-1"
+        >
+          {plan.title}
+        </Link>
+        <Link
+          href={`/plan-detail/${plan.planId}`}
+          className="regular-14 line-clamp-2 text-description"
+        >
           {plan.description || TEXT.noDescription}
-        </p>
+        </Link>
       </div>
-    </Link>
+    </div>
   );
 };
 

--- a/src/lib/queries/use-delete-plan.ts
+++ b/src/lib/queries/use-delete-plan.ts
@@ -2,14 +2,27 @@ import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { fetchDeletePlan } from '../apis/plan/plan.api';
 import useCustomToast from '../hooks/use-custom-toast';
 
+interface DeletePlanOptions {
+  onSuccess?: () => void;
+  onError?: (error: Error) => void;
+}
+
 /**
  * 일정을 삭제하는 React Query 훅
+ * @param userId - 사용자 ID
  * @returns 일정 삭제 뮤테이션 객체
  *
  * @example
  * ```typescript
- * const { mutate: deletePlan } = useDeletePlan();
- * deletePlan(planId);
+ * const { mutate: deletePlan } = useDeletePlan(userId);
+ * deletePlan(planId, {
+ *   onSuccess: () => {
+ *     // 삭제 성공 시 실행할 로직
+ *   },
+ *   onError: (error) => {
+ *     // 삭제 실패 시 실행할 로직
+ *   }
+ * });
  * ```
  */
 export const useDeletePlan = (userId: string) => {
@@ -18,13 +31,15 @@ export const useDeletePlan = (userId: string) => {
 
   return useMutation({
     mutationFn: fetchDeletePlan,
-    onSuccess: () => {
+    onSuccess: (_, __, options: DeletePlanOptions) => {
       // 일정 목록 캐시 갱신
       queryClient.invalidateQueries({ queryKey: ['filteredPlans', userId] });
       successToast('일정이 삭제되었습니다.');
+      options?.onSuccess?.();
     },
-    onError: (error: Error) => {
+    onError: (error: Error, __, context: DeletePlanOptions | undefined) => {
       successToast(error.message || '일정 삭제에 실패했습니다.');
+      context?.onError?.(error);
     },
   });
 };


### PR DESCRIPTION
## 📝 설명

<!-- 이 PR에서 무엇을 변경했는지 간단히 설명해주세요. -->

이 PR에서는 중간 발표 전 이슈가 생긴 부분에 대한 핫픽스 처리 작업을 진행하였습니다.

## 🔗 관련 이슈

<!-- 이 PR이 해결하는 이슈 번호를 적어주세요. -->

- #152 

## 🔍 변경 사항

<!-- 주요 변경 사항을 목록으로 작성해주세요. -->

- 일정 삭제 버튼 클릭시 페이지 강제이동 에러 해결
- alert 코드를 toast로 전부 수정
- 모달 디자인 수정

## ✅ 체크리스트

<!-- PR을 제출하기 전에 확인해야 할 항목들을 체크해주세요. -->

- [x] 코드가 프로젝트의 스타일 가이드를 준수합니다.
- [x] 모든 테스트가 통과했습니다.

## ℹ️ 추가 정보

<!-- 리뷰어가 알아야 할 추가 정보나 참고 자료가 있다면 여기에 작성해주세요. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Enhancements**
	- Improved plan deletion feedback with real-time success and error toast notifications.
	- Plan list now automatically refreshes after deleting a plan without changing the current page.
	- All validation and action feedback in plan scheduling is now delivered via toast notifications for a more consistent user experience.
- **UI Updates**
	- Plan cards are now only partially clickable: image, nickname/date, title, and description link to plan details, while other areas are non-clickable.
	- The "확인" (Confirm) button in the day selection required modal is now a single primary button for a cleaner interface.
	- Enhanced drag-and-drop functionality for places in plan scheduling, with improved interaction controls in read-only mode.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->