### PR TITLE
Feat/#40 air ticket

### DIFF
--- a/src/app/air-ticket/_components/ticket-list.tsx
+++ b/src/app/air-ticket/_components/ticket-list.tsx
@@ -28,7 +28,7 @@ const TicketList = ({
       {isEmpty ? (
         <div className="flex flex-col items-center justify-center py-10 text-center text-gray-600">
           <img
-            src="../emptyresult/ticket_empty_result.png"
+            src="../empty-result/ticket_empty_result.png"
             alt="검색 결과가 없어요"
             className="mb-4"
           />

--- a/src/app/air-ticket/_utils/ticket-uitls.ts
+++ b/src/app/air-ticket/_utils/ticket-uitls.ts
@@ -57,7 +57,8 @@ const sortFlights = (
   });
 };
 
-const formatTime = (timeStr: string) => {
+const formatTime = (timeString: string | number) => {
+  const timeStr = timeString.toString();
   if (!timeStr || timeStr.length !== 4) return timeStr;
   return `${timeStr.slice(0, 2)}:${timeStr.slice(2)}`;
 };

--- a/src/app/air-ticket/page.tsx
+++ b/src/app/air-ticket/page.tsx
@@ -70,6 +70,9 @@ const FlightSearch = () => {
       const baseDate = isGoFlight ? startDate : endDate;
 
       if (!baseDate) continue;
+      if (startDate && endDate && startDate > endDate) {
+        return dateAlert('오는날은 가는날보다 빠를수 없어요.');
+      }
       if (flightsToSave[0].arrPlandTime > flightsToSave[1].depPlandTime)
         return dateAlert('가는편의 도착시간이 오는편의 출발시간보다 빨라요!');
 

--- a/src/app/air-ticket/page.tsx
+++ b/src/app/air-ticket/page.tsx
@@ -70,9 +70,12 @@ const FlightSearch = () => {
       const baseDate = isGoFlight ? startDate : endDate;
 
       if (!baseDate) continue;
+      if (flightsToSave[0].arrPlandTime > flightsToSave[1].depPlandTime)
+        return dateAlert('가는편의 도착시간이 오는편의 출발시간보다 빨라요!');
 
       const departure_time = combineDateAndTime(baseDate, flight.depPlandTime);
       const arrive_time = combineDateAndTime(baseDate, flight.arrPlandTime);
+
       const { error } = await supabase.from('tickets').insert({
         user_id: user.id,
         departure_time,


### PR DESCRIPTION
## 📝 설명

예외처리를 추가했습니다

## 🔗 관련 이슈

- #40 

## 🔍 변경 사항

동일 다른시간일 경우에 가는편의 도착시간보다 오는편의 출발시간이 빠른경우 예매가 불가능 하도록 수정
하단의 데이트 설정이후에도 동일하게 오는편의 날짜가 가는편보다 빠를경우 예매가 불가능 하도록 수정

## ✅ 체크리스트


- [ ] 코드가 프로젝트의 스타일 가이드를 준수합니다.
- [ ] 모든 테스트가 통과했습니다.

## ℹ️ 추가 정보

<!-- 리뷰어가 알아야 할 추가 정보나 참고 자료가 있다면 여기에 작성해주세요. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Corrected the image path for the empty search result graphic to ensure proper display.

- **New Features**
	- Added validation to prevent users from selecting a return date earlier than the departure date.
	- Added validation to ensure that the arrival time of the outgoing flight is not later than the departure time of the return flight.

- **Refactor**
	- Improved time formatting utility to accept both string and numeric inputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->