### PR TITLE
Fix/#244 qa feedback 1

### DIFF
--- a/src/app/(mypage)/account/_components/_client/account-personal-info.tsx
+++ b/src/app/(mypage)/account/_components/_client/account-personal-info.tsx
@@ -20,8 +20,8 @@ const PersonalInfo = ({
   phone,
 }: {
   userId: string;
-  email: string;
-  phone: string;
+  email: string | null;
+  phone: string | null;
 }) => {
   const [isEditMode, setIsEditMode] = useState<boolean>(false);
   const { successToast } = useCustomToast();
@@ -41,7 +41,7 @@ const PersonalInfo = ({
   } = useForm<PhoneValues>({
     resolver: zodResolver(formSchema),
     defaultValues: {
-      phone: phone,
+      phone: phone || '',
     },
     mode: 'onChange',
   });

--- a/src/app/plan-detail/_components/client/core/plan-header.tsx
+++ b/src/app/plan-detail/_components/client/core/plan-header.tsx
@@ -143,8 +143,10 @@ const PlanHeader = memo(() => {
         }
 
         if (response) {
-          // Zustand 상태 업데이트
+          // Zustand 상태 업데이트 및 로컬 스토리지에 저장
           setPlanImg(response);
+          localStorage.setItem(`planImg_${planId}`, response);
+
           toast({
             title: '이미지 업로드 성공',
             description: '이미지가 성공적으로 업로드되었습니다.',

--- a/src/app/plan-detail/_components/client/features/card/place-card-sidemenu.tsx
+++ b/src/app/plan-detail/_components/client/features/card/place-card-sidemenu.tsx
@@ -8,7 +8,7 @@ import { CategoryType } from '@/types/category.type';
 import BookmarkIcon from '@/components/commons/bookmark-icon';
 import { Dialog, DialogContent, DialogTitle } from '@/components/ui/dialog';
 import PlaceModal from '@/components/features/plan/place-modal';
-import { getDefaultPlanImage } from '@/lib/utils/get-default-plan-image';
+import { getDefaultPlanOrPlaceImage } from '@/lib/utils/get-default-plan-image';
 
 const PLACE_IMAGE_SIZE = {
   width: 40,
@@ -42,7 +42,7 @@ const PlaceCardSidemenu = ({
   onAddPlace?: () => void;
   placeId: number;
 }) => {
-  const defaultImage = useMemo(() => getDefaultPlanImage(), []);
+  const defaultImage = useMemo(() => getDefaultPlanOrPlaceImage(placeId), []);
   const displayImageUrl = imageUrl || defaultImage;
 
   const [isDialogOpen, setIsDialogOpen] = useState(false);

--- a/src/app/plan-detail/_components/client/features/card/place-card.tsx
+++ b/src/app/plan-detail/_components/client/features/card/place-card.tsx
@@ -6,7 +6,7 @@ import { useMemo } from 'react';
 import CategoryBadge from '@/components/commons/category-badge';
 import { cn } from '@/lib/utils';
 import { CategoryType } from '@/types/category.type';
-import { getDefaultPlanImage } from '@/lib/utils/get-default-plan-image';
+import { getDefaultPlanOrPlaceImage } from '@/lib/utils/get-default-plan-image';
 
 const PLACE_IMAGE_SIZE = {
   width: 120,
@@ -39,6 +39,7 @@ const PlaceCard = ({
   index,
   dayNumber,
   category,
+  placeId,
   title,
   address,
   distance,
@@ -52,6 +53,7 @@ const PlaceCard = ({
   index: number;
   dayNumber: number;
   category: string;
+  placeId: number;
   title: string;
   address: string;
   distance?: number;
@@ -63,7 +65,7 @@ const PlaceCard = ({
   isDragging?: boolean;
 }) => {
   const dayColorSet = dayNumber % 2 === 1 ? COLORS.ODD : COLORS.EVEN;
-  const defaultImage = useMemo(() => getDefaultPlanImage(), []);
+  const defaultImage = useMemo(() => getDefaultPlanOrPlaceImage(placeId), []);
   const displayImageUrl = imageUrl || defaultImage;
 
   return (

--- a/src/app/plan-detail/_components/client/features/sidemenu/search-sidemenu.tsx
+++ b/src/app/plan-detail/_components/client/features/sidemenu/search-sidemenu.tsx
@@ -53,25 +53,68 @@ const SearchSidemenu = ({
   const [maxVisiblePages, setMaxVisiblePages] = useState(3);
   const [scrollPosition, setScrollPosition] = useState(0);
   const [isDaySelectModalOpen, setIsDaySelectModalOpen] = useState(false);
+  const [isSearching, setIsSearching] = useState(false);
   const containerRef = useRef<HTMLDivElement>(null);
   const resizeTimeoutRef = useRef<NodeJS.Timeout>();
   const listRef = useRef<HTMLDivElement>(null);
+  const searchTimeoutRef = useRef<NodeJS.Timeout>();
+  const [containerHeight, setContainerHeight] = useState(0);
 
   const { data: user } = useCurrentUser();
   const userId = user?.id || null;
 
   const { toggleBookmark, isBookmarked } = useBookmarkQuery(userId);
 
-  const filteredPlaces = places.filter((place) => {
-    const matchesCategory =
-      activeFilterTab === '전체' || place.category === activeFilterTab;
-    const matchesSearch =
-      place.title.toLowerCase().includes(searchQuery.toLowerCase()) ||
-      place.address.toLowerCase().includes(searchQuery.toLowerCase());
-    return matchesCategory && matchesSearch;
-  });
+  const filteredPlaces = useMemo(() => {
+    return places.filter((place) => {
+      const matchesCategory =
+        activeFilterTab === '전체' || place.category === activeFilterTab;
+      const matchesSearch =
+        place.title.toLowerCase().includes(searchQuery.toLowerCase()) ||
+        place.address.toLowerCase().includes(searchQuery.toLowerCase());
+      return matchesCategory && matchesSearch;
+    });
+  }, [places, searchQuery, activeFilterTab]);
 
   const totalPages = Math.ceil(filteredPlaces.length / ITEMS_PER_PAGE);
+
+  // 현재 페이지의 아이템들을 가져옴
+  const currentPageItems = filteredPlaces.slice(
+    (currentPage - 1) * ITEMS_PER_PAGE,
+    currentPage * ITEMS_PER_PAGE,
+  );
+
+  // 접힌 상태일 때는 현재 페이지 아이템 중 처음 3개만, 펼친 상태일 때는 모든 아이템이 보이도록 현재 페이지 아이템을 가져옴
+  const displayedPlaces = isExpanded
+    ? currentPageItems
+    : currentPageItems.slice(0, INITIAL_ITEMS);
+
+  // 컨테이너 높이 계산
+  useEffect(() => {
+    if (containerRef.current) {
+      const height = containerRef.current.offsetHeight;
+      setContainerHeight(height);
+    }
+  }, [displayedPlaces.length, isExpanded]);
+
+  // 검색어가 변경될 때 페이지를 1로 초기화
+  useEffect(() => {
+    if (searchTimeoutRef.current) {
+      clearTimeout(searchTimeoutRef.current);
+    }
+
+    setIsSearching(true);
+    searchTimeoutRef.current = setTimeout(() => {
+      setCurrentPage(1);
+      setIsSearching(false);
+    }, 300);
+
+    return () => {
+      if (searchTimeoutRef.current) {
+        clearTimeout(searchTimeoutRef.current);
+      }
+    };
+  }, [searchQuery, activeFilterTab]);
 
   const calculateMaxVisiblePages = useCallback(() => {
     if (!containerRef.current) return 3;
@@ -167,17 +210,6 @@ const SearchSidemenu = ({
     }
   };
 
-  // 현재 페이지의 아이템들을 가져옴
-  const currentPageItems = filteredPlaces.slice(
-    (currentPage - 1) * ITEMS_PER_PAGE,
-    currentPage * ITEMS_PER_PAGE,
-  );
-
-  // 접힌 상태일 때는 현재 페이지 아이템 중 처음 3개만, 펼친 상태일 때는 모든 아이템이 보이도록 현재 페이지 아이템을 가져옴
-  const displayedPlaces = isExpanded
-    ? currentPageItems
-    : currentPageItems.slice(0, INITIAL_ITEMS);
-
   const searchBar = (
     <div className="w-[240px] rounded-[12px] bg-gray-100 px-3 py-2">
       <div className="flex items-center gap-3">
@@ -221,15 +253,19 @@ const SearchSidemenu = ({
     >
       {/* 검색 결과 */}
       <div className="space-y-2" ref={containerRef}>
-        {displayedPlaces.length > 0 ? (
+        {isSearching ? (
+          <div className="flex h-full items-center justify-center">
+            <div className="h-6 w-6 animate-spin rounded-full border-2 border-secondary-300 border-t-transparent" />
+          </div>
+        ) : displayedPlaces.length > 0 ? (
           <div ref={listRef} className="overflow-y-auto">
             <AnimatePresence initial={false}>
               {displayedPlaces.map((place) => (
                 <motion.div
                   key={place.id}
-                  initial={{ opacity: 0, height: 0 }}
-                  animate={{ opacity: 1, height: 'auto' }}
-                  exit={{ opacity: 0, height: 0 }}
+                  initial={{ opacity: 0 }}
+                  animate={{ opacity: 1 }}
+                  exit={{ opacity: 0 }}
                   transition={{ duration: 0.2 }}
                 >
                   <PlaceCardSidemenu
@@ -262,7 +298,7 @@ const SearchSidemenu = ({
             )}
           </div>
         ) : (
-          <div className="flex items-center justify-center p-4">
+          <div className="flex h-full items-center justify-center p-4">
             <p>검색 결과가 없습니다.</p>
           </div>
         )}

--- a/src/app/plan-detail/_components/client/plan-form.tsx
+++ b/src/app/plan-detail/_components/client/plan-form.tsx
@@ -12,6 +12,7 @@ import {
   usePlanSetEndDate,
   usePlanSetIsReadOnly,
   usePlanSetId,
+  usePlanResetState,
 } from '@/zustand/plan.store';
 import { useEffect, useState } from 'react';
 
@@ -42,13 +43,23 @@ const PlanForm = ({
   const setIsReadOnly = usePlanSetIsReadOnly();
   const setDayPlaces = usePlanSetDayPlaces();
   const setPlanId = usePlanSetId();
+  const resetPlanState = usePlanResetState();
 
   // 초기값 설정
   useEffect(() => {
     if (initialPlan) {
+      // 상태 초기화 후 새로운 값 설정
+      resetPlanState();
+
       setTitle(initialPlan.title);
       setDescription(initialPlan.description || '');
-      setPlanImg(initialPlan.planImg || '');
+
+      // 로컬 스토리지에서 이미지 URL 확인
+      const storedImageUrl = localStorage.getItem(
+        `planImg_${initialPlan.planId}`,
+      );
+      setPlanImg(storedImageUrl || initialPlan.planImg || '');
+
       setPlanId(initialPlan.planId);
       setActiveTab('전체보기');
       setStartDate(
@@ -63,14 +74,8 @@ const PlanForm = ({
       setDayPlaces(initialDayPlaces || {});
     } else {
       // 새로운 일정을 만들 때는 모든 데이터를 초기화
-      setTitle('');
-      setDescription('');
-      setPlanImg('');
-      setActiveTab('전체보기');
-      setStartDate(null);
-      setEndDate(null);
+      resetPlanState();
       setIsReadOnly(isReadOnly);
-      setDayPlaces({});
     }
   }, [
     initialPlan,
@@ -85,6 +90,7 @@ const PlanForm = ({
     setEndDate,
     setIsReadOnly,
     setDayPlaces,
+    resetPlanState,
   ]);
 
   useEffect(() => {

--- a/src/app/plan-detail/_components/client/plan-form.tsx
+++ b/src/app/plan-detail/_components/client/plan-form.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { DayPlaces } from '@/types/plan-detail.type';
-import { Plan } from '@/types/plan.type';
+import { PlanWithDays } from '@/types/plan.type';
 import {
   usePlanSetTitle,
   usePlanSetDescription,
@@ -25,7 +25,7 @@ const PlanForm = ({
   initialDayPlaces,
   isReadOnly = true,
 }: {
-  initialPlan?: Omit<Plan, 'nickname' | 'createdAt' | 'publicAt' | 'isLiked'>;
+  initialPlan?: PlanWithDays;
   initialDayPlaces?: DayPlaces;
   isReadOnly?: boolean;
 }) => {

--- a/src/app/plan-detail/_components/server/places-renderer.tsx
+++ b/src/app/plan-detail/_components/server/places-renderer.tsx
@@ -63,6 +63,7 @@ const PlacesRenderer = ({
                         address={place.address}
                         distance={currentRoute?.distance}
                         duration={currentRoute?.duration}
+                        placeId={place.placeId}
                         imageUrl={place.image || ''}
                         isLastItem={index === places.length - 1}
                         onDelete={

--- a/src/lib/apis/auth/auth-server.api.ts
+++ b/src/lib/apis/auth/auth-server.api.ts
@@ -11,6 +11,7 @@ import {
   RegisterFormValues,
   AuthResult,
 } from '@/types/auth.type';
+import { User } from '@/types/user.type';
 
 /**
  * 로그인 서버 액션
@@ -157,7 +158,10 @@ export const fetchLogout = async (): Promise<AuthResult> => {
  * 현재 로그인한 사용자 정보를 가져오는 서버 액션
  * @returns 사용자 정보 또는 오류 객체
  */
-export const fetchGetCurrentUser = async () => {
+export const fetchGetCurrentUser = async (): Promise<{
+  user: User | null;
+  error: { message: string; status: number } | null;
+}> => {
   try {
     // 세션 먼저 확인하여 불필요한 getUser 호출 방지
     const supabase = await getServerClient();

--- a/src/lib/apis/map/directions.ts
+++ b/src/lib/apis/map/directions.ts
@@ -24,6 +24,23 @@ export const getCarRoute = async (
     throw new Error('출발지와 도착지를 설정해 주세요.');
   }
 
+  // 동일한 좌표가 연속해서 있는지 확인
+  const allPoints = [routeInfo.start, ...routeInfo.via, routeInfo.end];
+  const uniquePoints = allPoints.filter(
+    (point, index, self) =>
+      index ===
+      self.findIndex((p) => p.lat === point.lat && p.lng === point.lng),
+  );
+
+  // 동일한 좌표가 연속해서 있으면 빈 경로 반환
+  if (uniquePoints.length !== allPoints.length) {
+    return {
+      path: [],
+      summary: { distance: 0, duration: 0 },
+      sections: [],
+    };
+  }
+
   const origin = `${routeInfo.start.lng},${routeInfo.start.lat}`;
   const destination = `${routeInfo.end.lng},${routeInfo.end.lat}`;
   const viaPoints = routeInfo.via

--- a/src/lib/hooks/use-schedule.ts
+++ b/src/lib/hooks/use-schedule.ts
@@ -14,7 +14,7 @@ import { PATH } from '@/constants/path.constants';
 import { nanoid } from 'nanoid';
 import { useQueryClient } from '@tanstack/react-query';
 import { usePlanStore } from '@/zustand/plan.store';
-import { getDefaultPlanImage } from '@/lib/utils/get-default-plan-image';
+import { getDefaultPlanOrPlaceImage } from '@/lib/utils/get-default-plan-image';
 
 // 복사/붙여넣기 기능을 관리하는 훅
 export const useScheduleCopyPaste = (
@@ -71,7 +71,6 @@ export const useSchedulePlaces = (
   dayToDelete: number | null,
   setDayToDelete: (day: number | null) => void,
 ) => {
-  const { toast } = useToast();
   const { setDayPlaces: setStoreDayPlaces } = usePlanStore();
 
   /**
@@ -89,7 +88,10 @@ export const useSchedulePlaces = (
 
     const dayNumber = activeTab as number;
     const uniqueId = nanoid();
-    const newPlaceWithId = { ...newPlace, uniqueId };
+    const newPlaceWithId = {
+      ...newPlace,
+      uniqueId,
+    };
 
     const updatedDayPlaces = {
       ...dayPlaces,
@@ -306,7 +308,7 @@ export const useScheduleSavePlan = (
           description: description,
           travelStartDate: startDate?.toISOString() || '',
           travelEndDate: endDate?.toISOString() || '',
-          planImg: planImg || getDefaultPlanImage(),
+          planImg: planImg || getDefaultPlanOrPlaceImage(),
           public: true,
         });
         targetId = newPlanId;
@@ -378,7 +380,7 @@ export const useScheduleSavePlan = (
             description: description,
             travelStartDate: startDate?.toISOString() || '',
             travelEndDate: endDate?.toISOString() || '',
-            planImg: planImg || getDefaultPlanImage(),
+            planImg: planImg || getDefaultPlanOrPlaceImage(),
             public: false,
           });
           targetId = newPlanId;

--- a/src/lib/utils/get-default-plan-image.ts
+++ b/src/lib/utils/get-default-plan-image.ts
@@ -1,9 +1,17 @@
 import { DEFAULT_IMAGES } from '@/constants/plan.constants';
+
 /**
- * 일정의 기본 이미지를 랜덤하게 반환하는 함수
+ * 일정/장소의 기본 이미지를 반환하는 함수
+ * @param id - 장소의 ID (선택적)
  * @returns {string} 기본 이미지 URL
  */
-export const getDefaultPlanImage = () => {
-  const randomIndex = Math.floor(Math.random() * DEFAULT_IMAGES.length);
-  return DEFAULT_IMAGES[randomIndex];
+export const getDefaultPlanOrPlaceImage = (id?: number) => {
+  if (id === undefined) {
+    const randomIndex = Math.floor(Math.random() * DEFAULT_IMAGES.length);
+    return DEFAULT_IMAGES[randomIndex];
+  }
+
+  // ID를 기반으로 일관된 이미지 선택
+  const index = id % DEFAULT_IMAGES.length;
+  return DEFAULT_IMAGES[index];
 };

--- a/src/lib/utils/plan.util.ts
+++ b/src/lib/utils/plan.util.ts
@@ -1,0 +1,14 @@
+import { PlanWithDays } from '@/types/plan.type';
+import { User } from '@/types/user.type';
+/**
+ * 일정 접근 권한 체크 함수
+ * @param plan - 일정 데이터
+ * @param user - 사용자 데이터
+ * @returns 접근 권한 여부
+ */
+export const checkPlanAccess = (plan: PlanWithDays, user: User | null) => {
+  if (!plan.public && plan.userId !== user?.id) {
+    return false;
+  }
+  return true;
+};

--- a/src/types/plan.type.ts
+++ b/src/types/plan.type.ts
@@ -199,6 +199,9 @@ export type PlanState = {
   setRouteSummary: (routeSummary: {
     [key: number]: { distance: number; duration: number }[];
   }) => void;
+
+  // 상태 초기화 함수
+  resetPlanState: () => void;
 };
 
 /**

--- a/src/types/user.type.ts
+++ b/src/types/user.type.ts
@@ -1,7 +1,7 @@
 export type User = {
   id: string;
   email: string | null;
-  avatar_url: string | null;
-  nickname: string | null;
+  avatar_url: string;
+  nickname: string;
   phone: string | null;
 };

--- a/src/types/user.type.ts
+++ b/src/types/user.type.ts
@@ -1,0 +1,7 @@
+export type User = {
+  id: string;
+  email: string | null;
+  avatar_url: string | null;
+  nickname: string | null;
+  phone: string | null;
+};

--- a/src/zustand/plan.store.ts
+++ b/src/zustand/plan.store.ts
@@ -29,6 +29,19 @@ export const usePlanStore = create<PlanState>((set) => ({
   // 경로 요약 정보
   routeSummary: {},
   setRouteSummary: (routeSummary) => set({ routeSummary }),
+
+  // 이미지 업데이트 후 상태 초기화 함수 추가
+  resetPlanState: () =>
+    set({
+      title: '',
+      description: '',
+      planImg: null,
+      isReadOnly: false,
+      planId: 0,
+      dayPlaces: {},
+      activeTab: '전체보기',
+      routeSummary: {},
+    }),
 }));
 
 // Selectors
@@ -77,3 +90,6 @@ export const useScheduleModalStore = create<ScheduleModalStore>((set) => ({
   setIsPublicModalOpen: (isOpen) => set({ isPublicModalOpen: isOpen }),
   setDayToDelete: (day) => set({ dayToDelete: day }),
 }));
+
+export const usePlanResetState = () =>
+  usePlanStore((state) => state.resetPlanState);


### PR DESCRIPTION
## 📝 설명

<!-- 이 PR에서 무엇을 변경했는지 간단히 설명해주세요. -->

이 PR은 https://github.com/RE6CT/jeju-olleyo/issues/244 에 등록된 이슈를 해결하였습니다.

## 🔗 관련 이슈

<!-- 이 PR이 해결하는 이슈 번호를 적어주세요. -->

- #244 

## 🔍 변경 사항

<!-- 주요 변경 사항을 목록으로 작성해주세요. -->

- 비공개 일정에 URL 입력으로 접근 가능한 문제 해결
- 일정에 장소 추가시 동일한 장소를 연달아 추가하면 맵 영역이 사라지는 문제 해결
- 장소 모달에서 "내 일정에 추가" 버튼 클릭시 동일 장소라도 디폴트 이미지가 달라지는 문제 해결
- 일정 수정시 사이드메뉴에서 검색어 입력이 뒤쪽 페이지에서 했을 때 제대로 되지 않는 문제 해결
- 일정 수정에서 이미지 업데이트가 안되는 경우가 존재 해결

## ✅ 체크리스트

<!-- PR을 제출하기 전에 확인해야 할 항목들을 체크해주세요. -->

- [x] 코드가 프로젝트의 스타일 가이드를 준수합니다.
- [x] 모든 테스트가 통과했습니다.

## ℹ️ 추가 정보

<!-- 리뷰어가 알아야 할 추가 정보나 참고 자료가 있다면 여기에 작성해주세요. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced access control for private plans, ensuring only authorized users can view plan details and metadata.
  - Added persistent storage of uploaded plan images in the browser for improved image handling.
  - Implemented a utility to determine access permissions for plans.
  - Added a new user type definition for consistent user data handling.

- **Enhancements**
  - Default images for plans and places are now deterministically assigned based on their IDs, providing consistent visuals.
  - Improved search and filtering in the side menu with debounced loading indicators and better pagination.
  - Updated form and state management for plans, including a new method to reset plan state and improved initial value handling.

- **Bug Fixes**
  - Prevented route calculation when consecutive duplicate coordinates are detected.

- **Refactor**
  - Updated component and prop types for improved type safety and consistency, including nullable email/phone fields and updated plan/place types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->