### PR TITLE
Style/#252 responsive design card

### DIFF
--- a/src/app/my-plan/_components/client/plan-filter-section.tsx
+++ b/src/app/my-plan/_components/client/plan-filter-section.tsx
@@ -229,7 +229,12 @@ const PlanFilterSection = ({
             {currentPagePlans.map((plan) => (
               <React.Fragment key={plan.planId}>
                 <div className="w-[calc(50%-6px)] md:hidden">
-                  <PlanVerticalCard plan={plan} />
+                  <PlanVerticalCard
+                    plan={plan}
+                    onEdit={handleEdit}
+                    onDelete={() => handleDelete(plan.planId)}
+                    isDropdownVisible
+                  />
                 </div>
                 <div className="hidden md:block">
                   <PlanHorizontalCard

--- a/src/app/my-plan/_components/client/plan-filter-section.tsx
+++ b/src/app/my-plan/_components/client/plan-filter-section.tsx
@@ -113,7 +113,7 @@ const PlanFilterSection = ({
             onMouseLeave={() => handleMouseLeave(isDatePickerFocused)}
             className="border-none"
           >
-            <Button variant="outline" size="sm" disabled={isPlansLoading}>
+            <Button variant="ghost" size="sm" disabled={isPlansLoading}>
               <Image
                 src="/icons/mdi_filter_mobile.svg"
                 alt="filter icon"

--- a/src/app/my-plan/page.tsx
+++ b/src/app/my-plan/page.tsx
@@ -51,8 +51,8 @@ const MyPlanPage = async () => {
     const plans = await fetchGetAllPlansByUserId(user.id);
 
     return (
-      <main className="mx-auto w-full min-w-[375px] max-w-[375px] p-4 md:mt-[22px] md:max-w-[769px] md:px-7 md:py-0 lg:mt-0 lg:max-w-[1024px] lg:px-9 lg:py-0">
-        <div className="space-y-6 md:space-y-[21px]">
+      <main className="mx-auto w-full min-w-[375px] max-w-[375px] px-4 py-0 md:mt-[22px] md:max-w-[769px] md:px-7 md:py-0 md:py-4 lg:mt-0 lg:max-w-[1024px] lg:px-9 lg:py-0">
+        <div className="md:space-y-[21px] lg:space-y-6">
           <header className="hidden items-center justify-between md:flex">
             <div className="flex items-center gap-3">
               <h1 className="lg:bold-28 md:bold-24 leading-[130%]">

--- a/src/components/features/card/plan-vertical-card.tsx
+++ b/src/components/features/card/plan-vertical-card.tsx
@@ -36,7 +36,7 @@ const PlanVerticalCard = ({
           className="absolute right-2 top-2 md:right-4 md:top-4"
         />
         {onEdit && onDelete && isDropdownVisible && (
-          <div className="absolute right-2 top-10 md:hidden">
+          <div className="absolute right-2 top-10 block md:hidden">
             <PlanDropdown
               plan={plan as Plan}
               onEdit={onEdit}
@@ -45,13 +45,14 @@ const PlanVerticalCard = ({
               <Button
                 variant="ghost"
                 size="icon"
-                className="focus:ring-0 focus-visible:ring-0 focus-visible:ring-offset-0" // 포커스 효과 제거
+                className="h-8 w-8 focus:ring-0 focus-visible:ring-0 focus-visible:ring-offset-0" // 포커스 효과 제거
               >
                 <img
                   src="/icons/option.svg"
                   alt="option"
-                  width={24}
-                  height={24}
+                  width={16}
+                  height={16}
+                  className="h-4 w-4"
                 />
               </Button>
             </PlanDropdown>

--- a/src/components/features/card/plan-vertical-card.tsx
+++ b/src/components/features/card/plan-vertical-card.tsx
@@ -2,14 +2,24 @@ import Link from 'next/link';
 import Duration from '@/components/commons/duration';
 import PlanImage from '@/components/commons/plan-image';
 import { Separator } from '@/components/ui/separator';
-import { PlanVerticalCardProps } from '@/types/plan.type';
+import { Plan, PlanVerticalCardProps } from '@/types/plan.type';
 import LikeButton from '@/components/commons/like-button';
+import PlanDropdown from '@/components/commons/edit-and-delete-dropdown';
+import { Button } from '@/components/ui/button';
 
 /**
  * vertical한 플랜 카드 컴포넌트
  * @param plan - 플랜 카드를 위한 PlanCardType의 객체
+ * @param isDropdownVisible - 드롭다운 표시 여부
+ * @param onEdit - 수정 핸들러
+ * @param onDelete - 삭제 핸들러
  */
-const PlanVerticalCard = ({ plan }: PlanVerticalCardProps) => {
+const PlanVerticalCard = ({
+  plan,
+  isDropdownVisible,
+  onEdit,
+  onDelete,
+}: PlanVerticalCardProps) => {
   return (
     <Link href={`/plan-detail/${plan.planId}?isReadOnly=true`}>
       <div className="relative">
@@ -25,6 +35,28 @@ const PlanVerticalCard = ({ plan }: PlanVerticalCardProps) => {
           isLiked={plan.isLiked}
           className="absolute right-2 top-2 md:right-4 md:top-4"
         />
+        {onEdit && onDelete && isDropdownVisible && (
+          <div className="absolute right-2 top-10 md:hidden">
+            <PlanDropdown
+              plan={plan as Plan}
+              onEdit={onEdit}
+              onDelete={onDelete}
+            >
+              <Button
+                variant="ghost"
+                size="icon"
+                className="focus:ring-0 focus-visible:ring-0 focus-visible:ring-offset-0" // 포커스 효과 제거
+              >
+                <img
+                  src="/icons/option.svg"
+                  alt="option"
+                  width={24}
+                  height={24}
+                />
+              </Button>
+            </PlanDropdown>
+          </div>
+        )}
       </div>
 
       <div className="mt-2 flex flex-col gap-1">

--- a/src/components/layouts/nav.tsx
+++ b/src/components/layouts/nav.tsx
@@ -91,7 +91,7 @@ const Nav = () => {
             >
               <Link
                 href={PATH.PLAN_NEW}
-                className="flex w-[120px] items-center gap-[10px] rounded-[8px] px-0 py-2 font-semibold text-black transition-colors hover:bg-primary-100 hover:text-[#FF8533]"
+                className="flex w-[120px] items-center gap-[10px] rounded-[8px] px-0 py-2 text-black transition-colors hover:bg-primary-100 hover:text-[#FF8533]"
                 onClick={() => setPopoverOpen(false)}
               >
                 내 일정 만들기

--- a/src/components/layouts/nav.tsx
+++ b/src/components/layouts/nav.tsx
@@ -91,7 +91,7 @@ const Nav = () => {
             >
               <Link
                 href={PATH.PLAN_NEW}
-                className="flex w-[120px] items-center gap-[10px] rounded-[8px] px-0 py-2 text-black transition-colors hover:bg-primary-100 hover:text-[#FF8533]"
+                className="flex w-[120px] items-center justify-center gap-[10px] rounded-[8px] px-0 py-2 text-black transition-colors hover:bg-primary-100 hover:text-[#FF8533]"
                 onClick={() => setPopoverOpen(false)}
               >
                 내 일정 만들기
@@ -99,7 +99,7 @@ const Nav = () => {
               <div className="my-1 h-px w-full bg-[#E7EDF0]" />
               <Link
                 href={PATH.MYPLAN}
-                className="flex w-[120px] items-center gap-[10px] rounded-[8px] px-0 py-2 text-black transition-colors hover:bg-primary-100 hover:text-[#FF8533]"
+                className="flex w-[120px] items-center justify-center gap-[10px] rounded-[8px] px-0 py-2 text-black transition-colors hover:bg-primary-100 hover:text-[#FF8533]"
                 onClick={() => setPopoverOpen(false)}
               >
                 지난 일정 보기

--- a/src/lib/apis/plan/plan.api.ts
+++ b/src/lib/apis/plan/plan.api.ts
@@ -70,15 +70,33 @@ export const fetchGetFilteredPlansByUserId = async (
   // 날짜 필터링은 클라이언트 측에서 처리
   let filteredDataByDate = data;
   if (filterOptions.date) {
-    const userTimezone = Intl.DateTimeFormat().resolvedOptions().timeZone; // 브라우저 사용자의 시간대를 가져온다.
-    filteredDataByDate = filteredDataByDate.filter((plan) =>
-      isDateInRange(
-        filterOptions.date!,
-        plan.travel_start_date,
-        plan.travel_end_date,
-        userTimezone,
+    // UTC 기준으로 날짜를 비교하도록 수정
+    const targetDate = new Date(filterOptions.date);
+    const utcTargetDate = new Date(
+      Date.UTC(
+        targetDate.getFullYear(),
+        targetDate.getMonth(),
+        targetDate.getDate(),
       ),
     );
+
+    filteredDataByDate = filteredDataByDate.filter((plan) => {
+      const startDate = new Date(plan.travel_start_date);
+      const endDate = new Date(plan.travel_end_date);
+
+      const utcStartDate = new Date(
+        Date.UTC(
+          startDate.getFullYear(),
+          startDate.getMonth(),
+          startDate.getDate(),
+        ),
+      );
+      const utcEndDate = new Date(
+        Date.UTC(endDate.getFullYear(), endDate.getMonth(), endDate.getDate()),
+      );
+
+      return utcTargetDate >= utcStartDate && utcTargetDate <= utcEndDate;
+    });
   }
 
   return filteredDataByDate.map(camelize);

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -155,9 +155,10 @@ export async function middleware(request: NextRequest) {
     });
 
     const isAuthPage = pathname === PATH.SIGNIN || pathname === PATH.SIGNUP;
+    const isProtectedPage = pathname === PATH.PLAN_NEW || !isPublicPage;
 
     // 유효한 경로이면서 인증이 필요한 페이지에 로그인 없이 접근 시
-    if (!session && !isPublicPage) {
+    if (!session && isProtectedPage) {
       // 인증되지 않은 사용자가 보호된 경로에 접근, 로그인 페이지로 리다이렉트
       const url = request.nextUrl.clone();
       url.pathname = PATH.SIGNIN;

--- a/src/types/plan.type.ts
+++ b/src/types/plan.type.ts
@@ -106,8 +106,12 @@ export type PlanHorizontalCardProps = {
  * 수직형 계획 카드 컴포넌트의 props 타입
  */
 export type PlanVerticalCardProps = {
-  /** 계획 카드 정보 */
   plan: PlanCardType;
+  isDropdownVisible?: boolean;
+  /** 수정 핸들러 함수 */
+  onEdit?: (planId: number) => void;
+  /** 삭제 핸들러 함수 */
+  onDelete?: (planId: number) => void;
 };
 
 /**


### PR DESCRIPTION
## 📝 설명

<!-- 이 PR에서 무엇을 변경했는지 간단히 설명해주세요. -->

이 PR은 내 일정 페이지의 반응형 디자인 작업 내용을 보강하였습니다.

## 🔗 관련 이슈

<!-- 이 PR이 해결하는 이슈 번호를 적어주세요. -->

- #252 

## 🔍 변경 사항

<!-- 주요 변경 사항을 목록으로 작성해주세요. -->

- 모바일에서 내 일정 수정/삭제할 수 있도록 아이콘 추가
- 불필요한 padding, margin 제거

## ✅ 체크리스트

<!-- PR을 제출하기 전에 확인해야 할 항목들을 체크해주세요. -->

- [x] 코드가 프로젝트의 스타일 가이드를 준수합니다.
- [x] 모든 테스트가 통과했습니다.

## ℹ️ 추가 정보

<!-- 리뷰어가 알아야 할 추가 정보나 참고 자료가 있다면 여기에 작성해주세요. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added edit and delete options with a visible dropdown menu to plan cards on mobile devices, allowing users to manage their plans more easily.
- **Style**
  - Updated filter button appearance for a more streamlined look.
  - Improved responsive spacing and padding for better layout consistency across different screen sizes.
- **Bug Fixes**
  - Enhanced date filtering to use consistent UTC-based comparisons for more accurate plan filtering.
- **Chores**
  - Adjusted navigation menu link alignment for improved visual balance on the login popover.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->