### PR TITLE
Style/#281 internal test issue

### DIFF
--- a/src/app/(mypage)/likes/components/_client/likes-list.tsx
+++ b/src/app/(mypage)/likes/components/_client/likes-list.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import PlanHorizontalCard from '@/components/features/card/plan-horizontal_card';
+import PlanHorizontalCard from '@/components/features/card/plan-horizontal-card';
 import useAuth from '@/lib/hooks/use-auth';
 import { useGetDataCount } from '@/lib/queries/use-get-data-count';
 import { Plan } from '@/types/plan.type';

--- a/src/app/my-plan/_components/client/plan-filter-section.tsx
+++ b/src/app/my-plan/_components/client/plan-filter-section.tsx
@@ -1,7 +1,7 @@
 'use client';
 import Image from 'next/image';
 import Loading from '@/app/loading';
-import PlanHorizontalCard from '@/components/features/card/plan-horizontal_card';
+import PlanHorizontalCard from '@/components/features/card/plan-horizontal-card';
 import { Button } from '@/components/ui/button';
 import Pagination from '@/components/ui/pagination';
 import {
@@ -240,7 +240,6 @@ const PlanFilterSection = ({
                   <PlanHorizontalCard
                     plan={plan}
                     nickname={userNickname}
-                    onEdit={handleEdit}
                     onDelete={() => handleDelete(plan.planId)}
                   />
                 </div>

--- a/src/app/plan-detail/[planId]/page.tsx
+++ b/src/app/plan-detail/[planId]/page.tsx
@@ -74,20 +74,22 @@ const PlanDetailPage = async ({
 
     return (
       <main className="mx-auto flex w-full min-w-[375px] max-w-[1024px] max-w-[375px] flex-col gap-5 bg-white p-4 md:max-w-[769px] md:px-5 md:py-3 lg:max-w-[1024px] lg:px-6 lg:py-5">
-        <header className="hidden items-center justify-between md:flex">
-          <div className="flex items-center gap-3">
-            <h1 className="font-bold leading-[130%] md:text-24 lg:text-28">
-              내 일정 만들기
-            </h1>
-            <Image
-              src="/character/happy_color.svg"
-              alt="happy icon"
-              width={HAPPY_IMAGE.width}
-              height={HAPPY_IMAGE.height}
-            />
-          </div>
-          {!isReadOnly && <PlanSaveButton />}
-        </header>
+        {isOwner && (
+          <header className="hidden items-center justify-between md:flex">
+            <div className="flex items-center gap-3">
+              <h1 className="font-bold leading-[130%] md:text-24 lg:text-28">
+                내 일정 만들기
+              </h1>
+              <Image
+                src="/character/happy_color.svg"
+                alt="happy icon"
+                width={HAPPY_IMAGE.width}
+                height={HAPPY_IMAGE.height}
+              />
+            </div>
+            {!isReadOnly && <PlanSaveButton />}
+          </header>
+        )}
         <section>
           <PlanForm
             initialPlan={plan}

--- a/src/app/plan-detail/_components/client/core/plan-header.tsx
+++ b/src/app/plan-detail/_components/client/core/plan-header.tsx
@@ -206,8 +206,9 @@ const PlanHeader = memo(() => {
               src={previewImage}
               alt="썸네일"
               fill
-              sizes="(max-width: 768px) 100vw, (max-width: 1200px) 50vw, 25vw"
+              sizes="(max-width: 768px) 110px, (max-width: 1200px) 252px, 252px"
               className="object-cover object-center"
+              unoptimized
             />
           ) : (
             <>

--- a/src/app/plan-detail/_components/client/core/plan-header.tsx
+++ b/src/app/plan-detail/_components/client/core/plan-header.tsx
@@ -340,7 +340,7 @@ const PlanHeader = memo(() => {
           value={description}
           onChange={(e) => setDescription(e.target.value)}
           maxLength={MAX_TEXT_LENGTH.DESCRIPTION}
-          className={`w-full resize-none border-0 bg-transparent p-0 text-[10px] focus-visible:ring-0 focus-visible:ring-offset-0 md:h-[160px] md:rounded-[12px] md:border md:border-gray-200 md:py-5 md:text-[14px] md:leading-[20px] ${
+          className={`h-[60px] w-full resize-none border-0 bg-transparent p-0 text-[11px] focus-visible:ring-0 focus-visible:ring-offset-0 md:h-[160px] md:rounded-[12px] md:border md:border-gray-200 md:py-5 md:text-[14px] md:leading-[20px] ${
             isReadOnly ? 'pl-0 md:pl-5' : 'pl-6 md:pl-12'
           }`}
           readOnly={isReadOnly}

--- a/src/app/plan-detail/_components/client/core/plan-map.tsx
+++ b/src/app/plan-detail/_components/client/core/plan-map.tsx
@@ -32,14 +32,14 @@ const PlanMap = memo(() => {
   return (
     <div className="h-[121px] w-full overflow-hidden rounded-[12px] md:h-[228px]">
       {isLoading && <Loading />}
-      {error && <ErrorMessage message={error} />}
       <KakaoMap
         {...DEFAULT_MAP_OPTIONS}
         onMapLoad={handleMapLoad}
         onError={handleMapError}
       />
-      {map && !isLoading && !error && (
+      {map && !isLoading && (
         <>
+          {error && <ErrorMessage message={error} />}
           <Clusterer
             map={map}
             markers={markers}

--- a/src/app/plan-detail/_components/client/core/plan-schedule.tsx
+++ b/src/app/plan-detail/_components/client/core/plan-schedule.tsx
@@ -199,6 +199,7 @@ const PlanSchedule = memo(() => {
   const activeTab = usePlanActiveTab();
   const setActiveTab = usePlanSetActiveTab();
   const isReadOnly = usePlanIsReadOnly();
+  const { setIsSaveModalOpen, setIsPublicModalOpen } = useScheduleModalStore();
 
   const { setIsDeleteModalOpen, dayToDelete, setDayToDelete } =
     useScheduleModalStore();
@@ -215,6 +216,10 @@ const PlanSchedule = memo(() => {
       dayToDelete,
       setDayToDelete,
     );
+
+  const handleSaveButtonClick = () => {
+    setIsSaveModalOpen(true);
+  };
 
   const dayCount = calculateTotalDays(startDate, endDate);
 
@@ -375,6 +380,16 @@ const PlanSchedule = memo(() => {
                         </div>
                       </div>
                     ),
+                  )}
+                  {!isReadOnly && (
+                    <div className="sticky bottom-0 left-0 right-0 z-50 mt-4 flex w-full justify-center bg-white p-4 md:hidden">
+                      <Button
+                        onClick={handleSaveButtonClick}
+                        className="w-full rounded-[12px] bg-primary-500 p-[10px] text-white hover:bg-primary-600"
+                      >
+                        저장하기
+                      </Button>
+                    </div>
                   )}
                 </div>
               ) : (

--- a/src/app/plan-detail/_components/client/core/plan-schedule.tsx
+++ b/src/app/plan-detail/_components/client/core/plan-schedule.tsx
@@ -478,7 +478,7 @@ const PlanSchedule = memo(() => {
       >
         <SheetContent
           side="bottom"
-          className="mx-auto h-fit w-[282px] rounded-t-[20px]"
+          className="mx-auto h-[60vh] w-full max-w-[282px] rounded-t-[20px]"
         >
           <SheetTitle className="sr-only">
             {openSheet === 'search' ? '장소 검색' : '내 북마크'}

--- a/src/app/plan-detail/_components/client/core/plan-schedule.tsx
+++ b/src/app/plan-detail/_components/client/core/plan-schedule.tsx
@@ -228,56 +228,66 @@ const PlanSchedule = memo(() => {
   );
 
   const handleAddPlace = (place: Place, activeTab: string | number) => {
-    const uniqueId = nanoid();
-    const newPlaceWithId = { ...place, uniqueId } as PlaceWithUniqueId;
+    try {
+      const uniqueId = nanoid();
+      const newPlaceWithId = { ...place, uniqueId } as PlaceWithUniqueId;
 
-    if (typeof activeTab === 'string') {
-      // 전체보기 상태일 때는 첫 번째 날짜에 추가
-      const firstDay = 1;
-      const currentDayPlaces = dayPlaces[firstDay] || [];
+      if (typeof activeTab === 'string') {
+        // 전체보기 상태일 때는 첫 번째 날짜에 추가
+        const firstDay = 1;
+        const currentDayPlaces = dayPlaces[firstDay] || [];
 
-      // 동일한 장소가 이미 있는지 확인
-      const isDuplicate = currentDayPlaces.some(
-        (p) => p.placeId === place.placeId,
-      );
+        // 동일한 장소가 이미 있는지 확인
+        const isDuplicate = currentDayPlaces.some(
+          (p) => p.placeId === place.placeId,
+        );
 
-      if (isDuplicate) {
-        toast({
-          title: '장소 추가 실패',
-          description: '이미 추가된 장소입니다.',
-          variant: 'destructive',
-        });
-        return;
+        if (isDuplicate) {
+          toast({
+            title: '장소 추가 실패',
+            description: '이미 추가된 장소입니다.',
+            variant: 'destructive',
+          });
+          return;
+        }
+
+        const updatedDayPlaces = {
+          ...dayPlaces,
+          [firstDay]: [...currentDayPlaces, newPlaceWithId],
+        };
+        setDayPlaces(updatedDayPlaces);
+      } else {
+        // 특정 날짜가 선택된 상태
+        const currentDayPlaces = dayPlaces[activeTab] || [];
+
+        // 동일한 장소가 이미 있는지 확인
+        const isDuplicate = currentDayPlaces.some(
+          (p) => p.placeId === place.placeId,
+        );
+
+        if (isDuplicate) {
+          toast({
+            title: '장소 추가 실패',
+            description: '이미 추가된 장소입니다.',
+            variant: 'destructive',
+          });
+          return;
+        }
+
+        const updatedDayPlaces = {
+          ...dayPlaces,
+          [activeTab]: [...currentDayPlaces, newPlaceWithId],
+        };
+        setDayPlaces(updatedDayPlaces);
       }
-
-      const updatedDayPlaces = {
-        ...dayPlaces,
-        [firstDay]: [...currentDayPlaces, newPlaceWithId],
-      };
-      setDayPlaces(updatedDayPlaces);
-    } else {
-      // 특정 날짜가 선택된 상태
-      const currentDayPlaces = dayPlaces[activeTab] || [];
-
-      // 동일한 장소가 이미 있는지 확인
-      const isDuplicate = currentDayPlaces.some(
-        (p) => p.placeId === place.placeId,
-      );
-
-      if (isDuplicate) {
-        toast({
-          title: '장소 추가 실패',
-          description: '이미 추가된 장소입니다.',
-          variant: 'destructive',
-        });
-        return;
-      }
-
-      const updatedDayPlaces = {
-        ...dayPlaces,
-        [activeTab]: [...currentDayPlaces, newPlaceWithId],
-      };
-      setDayPlaces(updatedDayPlaces);
+    } catch (error) {
+      console.error('장소 추가 중 오류 발생:', error);
+      toast({
+        title: '장소 추가 실패',
+        description:
+          '장소 추가 중 오류가 발생했습니다. 잠시 후 다시 시도해주세요.',
+        variant: 'destructive',
+      });
     }
   };
 

--- a/src/app/plan-detail/_components/client/core/plan-schedule.tsx
+++ b/src/app/plan-detail/_components/client/core/plan-schedule.tsx
@@ -234,16 +234,48 @@ const PlanSchedule = memo(() => {
     if (typeof activeTab === 'string') {
       // 전체보기 상태일 때는 첫 번째 날짜에 추가
       const firstDay = 1;
+      const currentDayPlaces = dayPlaces[firstDay] || [];
+
+      // 동일한 장소가 이미 있는지 확인
+      const isDuplicate = currentDayPlaces.some(
+        (p) => p.placeId === place.placeId,
+      );
+
+      if (isDuplicate) {
+        toast({
+          title: '장소 추가 실패',
+          description: '이미 추가된 장소입니다.',
+          variant: 'destructive',
+        });
+        return;
+      }
+
       const updatedDayPlaces = {
         ...dayPlaces,
-        [firstDay]: [...(dayPlaces[firstDay] || []), newPlaceWithId],
+        [firstDay]: [...currentDayPlaces, newPlaceWithId],
       };
       setDayPlaces(updatedDayPlaces);
     } else {
       // 특정 날짜가 선택된 상태
+      const currentDayPlaces = dayPlaces[activeTab] || [];
+
+      // 동일한 장소가 이미 있는지 확인
+      const isDuplicate = currentDayPlaces.some(
+        (p) => p.placeId === place.placeId,
+      );
+
+      if (isDuplicate) {
+        toast({
+          title: '장소 추가 실패',
+          description: '이미 추가된 장소입니다.',
+          variant: 'destructive',
+        });
+        return;
+      }
+
       const updatedDayPlaces = {
         ...dayPlaces,
-        [activeTab]: [...(dayPlaces[activeTab] || []), newPlaceWithId],
+        [activeTab]: [...currentDayPlaces, newPlaceWithId],
       };
       setDayPlaces(updatedDayPlaces);
     }

--- a/src/app/plan-detail/_components/client/core/plan-schedule.tsx
+++ b/src/app/plan-detail/_components/client/core/plan-schedule.tsx
@@ -535,7 +535,7 @@ const PlanSchedule = memo(() => {
       >
         <SheetContent
           side="bottom"
-          className="mx-auto h-[60vh] w-full max-w-[282px] rounded-t-[20px]"
+          className="mx-auto h-[60vh] max-h-[500px] w-full max-w-[282px] rounded-t-[20px]"
         >
           <SheetTitle className="sr-only">
             {openSheet === 'search' ? '장소 검색' : '내 북마크'}

--- a/src/app/plan-detail/_components/client/features/card/place-card-sidemenu.tsx
+++ b/src/app/plan-detail/_components/client/features/card/place-card-sidemenu.tsx
@@ -53,14 +53,14 @@ const PlaceCardSidemenu = ({
         <div className="flex items-center gap-3">
           {/* 장소 이미지 */}
           <div
-            className={`h-[40px] w-[40px] overflow-hidden rounded-[4px] md:h-[30px] md:w-[30px] lg:h-[40px] lg:w-[40px] ${!imageUrl && 'bg-gray-200'}`}
+            className={`relative h-[40px] w-[40px] min-w-[40px] overflow-hidden rounded-[4px] md:h-[30px] md:w-[30px] md:min-w-[30px] lg:h-[40px] lg:w-[40px] lg:min-w-[40px] ${!imageUrl && 'bg-gray-200'}`}
           >
             <Image
               src={displayImageUrl}
               alt=""
-              width={PLACE_IMAGE_SIZE.width}
-              height={PLACE_IMAGE_SIZE.height}
-              className="h-full w-full object-cover"
+              fill
+              sizes="(max-width: 768px) 30px, 40px"
+              className="absolute inset-0 object-cover"
               onError={handleImageLoadError}
             />
           </div>

--- a/src/app/plan-detail/_components/client/features/card/place-card-sidemenu.tsx
+++ b/src/app/plan-detail/_components/client/features/card/place-card-sidemenu.tsx
@@ -49,7 +49,7 @@ const PlaceCardSidemenu = ({
 
   return (
     <>
-      <div className="lg:w-[240px]` flex w-[240px] items-center justify-between md:w-[182px]">
+      <div className="flex w-[240px] items-center justify-between md:w-[182px] lg:w-[240px]">
         <div className="flex items-center gap-3">
           {/* 장소 이미지 */}
           <div

--- a/src/app/plan-detail/_components/client/features/card/place-card-sidemenu.tsx
+++ b/src/app/plan-detail/_components/client/features/card/place-card-sidemenu.tsx
@@ -49,7 +49,7 @@ const PlaceCardSidemenu = ({
 
   return (
     <>
-      <div className="flex w-[240px] items-center justify-between md:w-[182px] lg:w-[240px]">
+      <div className="lg:w-[240px]` flex w-[240px] items-center justify-between md:w-[182px]">
         <div className="flex items-center gap-3">
           {/* 장소 이미지 */}
           <div

--- a/src/app/plan-detail/_components/client/features/card/place-card.tsx
+++ b/src/app/plan-detail/_components/client/features/card/place-card.tsx
@@ -84,7 +84,7 @@ const PlaceCard = ({
       </div>
 
       {/* 카드 본문 */}
-      <div className="flex w-full items-center gap-[15px] rounded-lg border border-gray-100 bg-white p-[8.72px] shadow-[0px_2px_4px_1px_rgba(0,0,0,0.10)] transition-shadow duration-200 hover:shadow-[0px_4px_8px_2px_rgba(0,0,0,0.15)] md:gap-5 md:p-3">
+      <div className="flex w-full items-start gap-[15px] rounded-lg border border-gray-100 bg-white p-[8.72px] shadow-[0px_2px_4px_1px_rgba(0,0,0,0.10)] transition-shadow duration-200 hover:shadow-[0px_4px_8px_2px_rgba(0,0,0,0.15)] md:gap-5 md:p-3">
         {/* 장소 이미지 */}
         <div
           className={`h-[72px] w-[72px] shrink-0 overflow-hidden rounded-lg bg-gray-100 md:h-[92px] md:w-[92px]`}
@@ -99,7 +99,7 @@ const PlaceCard = ({
         </div>
 
         {/* 장소 정보 */}
-        <div className="flex flex-1 shrink-0 flex-col items-start justify-start md:h-[92px] md:gap-1">
+        <div className="flex flex-1 shrink-0 flex-col items-start justify-start gap-1">
           <div className="w-fit">
             <CategoryBadge
               category={category as CategoryType}
@@ -119,9 +119,9 @@ const PlaceCard = ({
             <span className="text-9 text-gray-400">{address}</span>
           </div>
           {!isLastItem && (
-            <div className="text-9 mt-auto flex items-center gap-[2.91px] md:gap-1">
+            <div className="flex items-center gap-[2.91px] text-9 md:gap-1">
               <div
-                className={`text-8 md:regular-12 flex aspect-square h-[15px] w-[15px] shrink-0 flex-col items-center justify-center gap-[10px] rounded-[12px] md:h-[20px] md:w-[20px] ${dayColorSet.bg} text-white md:p-[3px_9px]`}
+                className={`md:regular-12 flex aspect-square h-[15px] w-[15px] shrink-0 flex-col items-center justify-center gap-[10px] rounded-[12px] text-8 md:h-[20px] md:w-[20px] ${dayColorSet.bg} text-white md:p-[3px_9px]`}
               >
                 {index + 1}
               </div>

--- a/src/app/plan-detail/_components/client/features/comment/comment-input.tsx
+++ b/src/app/plan-detail/_components/client/features/comment/comment-input.tsx
@@ -28,7 +28,11 @@ const CommentInput = ({ planId }: { planId: number }) => {
     }
     mutate({ userId: user.id, content: inputText, planId });
     successToast('댓글이 등록되었습니다.');
-    setInputText('');
+    // 현재 실행 중인 이벤트 루프가 완료된 후에 콜백 함수를 실행
+    // input 초기화가 바텀시트의 상태 변경과 동시에 발생하지 않도록
+    setTimeout(() => {
+      setInputText('');
+    }, 0);
   };
 
   return (

--- a/src/app/plan-detail/_components/client/features/sidemenu/bookmark-sidemenu.tsx
+++ b/src/app/plan-detail/_components/client/features/sidemenu/bookmark-sidemenu.tsx
@@ -125,7 +125,7 @@ const BookmarkSidemenu = ({
   }, [activeFilterTab]);
 
   const handleAddPlace = (place: Place) => {
-    if (selectedDay === null) {
+    if (!isMobile && selectedDay === null) {
       setIsDaySelectModalOpen(true);
       return;
     }

--- a/src/app/plan-detail/_components/client/features/sidemenu/search-sidemenu.tsx
+++ b/src/app/plan-detail/_components/client/features/sidemenu/search-sidemenu.tsx
@@ -59,6 +59,7 @@ const SearchSidemenu = ({
   const listRef = useRef<HTMLDivElement>(null);
   const searchTimeoutRef = useRef<NodeJS.Timeout>();
   const [containerHeight, setContainerHeight] = useState(0);
+  const [isMobile, setIsMobile] = useState(false);
 
   const { data: user } = useCurrentUser();
   const userId = user?.id || null;
@@ -167,8 +168,21 @@ const SearchSidemenu = ({
     fetchData();
   }, [userId]);
 
+  useEffect(() => {
+    const checkMobile = () => {
+      setIsMobile(window.innerWidth < 768);
+    };
+
+    checkMobile();
+    window.addEventListener('resize', checkMobile);
+
+    return () => {
+      window.removeEventListener('resize', checkMobile);
+    };
+  }, []);
+
   const handleAddPlace = (place: Place) => {
-    if (selectedDay === null) {
+    if (!isMobile && selectedDay === null) {
       setIsDaySelectModalOpen(true);
       return;
     }

--- a/src/app/plan-detail/_components/client/plan-form.tsx
+++ b/src/app/plan-detail/_components/client/plan-form.tsx
@@ -139,7 +139,7 @@ const PlanForm = ({
               </SheetTrigger>
               <SheetContent
                 side="bottom"
-                className="mx-auto h-[470px] w-[375px] rounded-t-[20px] p-[16px_20px_12px_20px]"
+                className="mx-auto h-[60vh] w-full max-w-[375px] rounded-t-[20px] p-[16px_20px_12px_20px]"
               >
                 <SheetTitle className="sr-only">일정 정보</SheetTitle>
                 <PlanSidemenu />

--- a/src/app/plan-detail/_components/client/plan-form.tsx
+++ b/src/app/plan-detail/_components/client/plan-form.tsx
@@ -139,7 +139,7 @@ const PlanForm = ({
               </SheetTrigger>
               <SheetContent
                 side="bottom"
-                className="mx-auto h-[60vh] w-full max-w-[375px] rounded-t-[20px] p-[16px_20px_12px_20px]"
+                className="mx-auto h-[60vh] max-h-[500px] w-full max-w-[375px] rounded-t-[20px] p-[16px_20px_12px_20px]"
               >
                 <SheetTitle className="sr-only">일정 정보</SheetTitle>
                 <PlanSidemenu />

--- a/src/components/commons/edit-and-delete-dropdown.tsx
+++ b/src/components/commons/edit-and-delete-dropdown.tsx
@@ -1,4 +1,5 @@
 import { Pencil, Trash2 } from 'lucide-react';
+import Link from 'next/link';
 
 import {
   DropdownMenu,
@@ -11,25 +12,23 @@ import { Plan } from '@/types/plan.type';
 
 const PlanDropdown = ({
   plan,
-  onEdit,
   onDelete,
   children,
 }: {
   plan: Plan;
-  onEdit: (planId: number) => void;
   onDelete: (planId: number) => void;
   children: React.ReactNode;
 }) => {
   return (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>{children}</DropdownMenuTrigger>
-      <DropdownMenuContent align="end">
-        {onEdit && (
-          <DropdownMenuItem onClick={() => onEdit(plan.planId)}>
+      <DropdownMenuContent align="end" className="dropdown-menu">
+        <Link href={`/plan-detail/${plan.planId}?isReadOnly=false`}>
+          <DropdownMenuItem>
             <Pencil className="mr-2 h-4 w-4" />
             {TEXT.edit}
           </DropdownMenuItem>
-        )}
+        </Link>
         {onDelete && (
           <DropdownMenuItem
             onClick={() => onDelete(plan.planId)}

--- a/src/components/features/card/plan-horizontal-card.tsx
+++ b/src/components/features/card/plan-horizontal-card.tsx
@@ -31,8 +31,8 @@ import LikeButton from '@/components/commons/like-button';
 const PlanHorizontalCard = ({
   plan,
   nickname,
-  onEdit,
   onDelete,
+  onUpdate,
 }: PlanHorizontalCardProps) => {
   return (
     <Link
@@ -59,26 +59,22 @@ const PlanHorizontalCard = ({
       <div className="flex flex-1 flex-col gap-2">
         <div className="relative">
           {/* 드롭다운 메뉴 */}
-          {onEdit && onDelete && (
-            <div
-              className="absolute right-0"
-              onClick={(e) => e.stopPropagation()}
-            >
-              <PlanDropdown plan={plan} onEdit={onEdit} onDelete={onDelete}>
-                <Button
-                  variant="ghost"
-                  size="icon"
-                  className="focus:ring-0 focus-visible:ring-0 focus-visible:ring-offset-0" // 포커스 효과 제거
-                >
-                  <Image
-                    src="/icons/option.svg"
-                    alt="option"
-                    width={24}
-                    height={24}
-                  />
-                </Button>
-              </PlanDropdown>
-            </div>
+          {onDelete && (
+            <PlanDropdown plan={plan} onDelete={onDelete}>
+              <Button
+                variant="ghost"
+                size="icon"
+                className="focus:ring-0 focus-visible:ring-0 focus-visible:ring-offset-0"
+              >
+                <img
+                  src="/icons/option.svg"
+                  alt="option"
+                  width={16}
+                  height={16}
+                  className="h-4 w-4"
+                />
+              </Button>
+            </PlanDropdown>
           )}
         </div>
 

--- a/src/components/features/card/plan-vertical-card.tsx
+++ b/src/components/features/card/plan-vertical-card.tsx
@@ -20,8 +20,17 @@ const PlanVerticalCard = ({
   onEdit,
   onDelete,
 }: PlanVerticalCardProps) => {
+  const handleCardClick = (e: React.MouseEvent) => {
+    if (e.target instanceof HTMLElement && e.target.closest('.dropdown-menu')) {
+      e.preventDefault();
+    }
+  };
+
   return (
-    <Link href={`/plan-detail/${plan.planId}?isReadOnly=true`}>
+    <Link
+      href={`/plan-detail/${plan.planId}?isReadOnly=true`}
+      onClick={handleCardClick}
+    >
       <div className="relative">
         <div className="relative aspect-[83/58] h-[116px] w-[166px] md:aspect-[310/216] md:h-auto md:w-full">
           <PlanImage
@@ -37,15 +46,11 @@ const PlanVerticalCard = ({
         />
         {onEdit && onDelete && isDropdownVisible && (
           <div className="absolute right-2 top-10 block md:hidden">
-            <PlanDropdown
-              plan={plan as Plan}
-              onEdit={onEdit}
-              onDelete={onDelete}
-            >
+            <PlanDropdown plan={plan as Plan} onDelete={onDelete}>
               <Button
                 variant="ghost"
                 size="icon"
-                className="h-8 w-8 focus:ring-0 focus-visible:ring-0 focus-visible:ring-offset-0" // 포커스 효과 제거
+                className="h-8 w-8 focus:ring-0 focus-visible:ring-0 focus-visible:ring-offset-0"
               >
                 <img
                   src="/icons/option.svg"

--- a/src/components/ui/sheet.tsx
+++ b/src/components/ui/sheet.tsx
@@ -62,6 +62,8 @@ const SheetContent = React.forwardRef<
     <SheetPrimitive.Content
       ref={ref}
       className={cn(sheetVariants({ side }), className)}
+      autoFocus={false}
+      onOpenAutoFocus={(e) => e.preventDefault()}
       {...props}
     >
       {children}

--- a/src/lib/apis/plan/plan.api.ts
+++ b/src/lib/apis/plan/plan.api.ts
@@ -403,8 +403,8 @@ export const fetchUploadPlanImage = async (
   const { error: uploadError } = await supabase.storage
     .from('plan-images')
     .upload(filePath, file, {
-      cacheControl: '3600',
-      upsert: false,
+      cacheControl: '0',
+      upsert: true, // 동일 파일명으로 업로드할 때 덮어쓰기 가능하도록
     });
 
   if (uploadError) {
@@ -414,7 +414,9 @@ export const fetchUploadPlanImage = async (
   // 업로드된 이미지의 공개 URL 가져오기
   const {
     data: { publicUrl },
-  } = supabase.storage.from('plan-images').getPublicUrl(filePath);
+  } = supabase.storage.from('plan-images').getPublicUrl(filePath, {
+    download: false, // 파일 다운로드 없이 공개 URL만 가져오도록
+  });
 
   // 데이터베이스에 이미지 URL 업데이트
   const { error: updateError } = await supabase

--- a/src/lib/hooks/use-plan-map.ts
+++ b/src/lib/hooks/use-plan-map.ts
@@ -132,7 +132,7 @@ export const usePlanMap = ({
             typeof position.lat !== 'number' ||
             typeof position.lng !== 'number'
           ) {
-            setError('잘못된 위치 정보입니다.');
+            setError('잘못된 위치 정보입니다. 장소를 다시 확인해주세요.');
             return null;
           }
 
@@ -233,7 +233,10 @@ export const usePlanMap = ({
         const prevSummary = usePlanStore.getState().routeSummary;
         setRouteSummary({ ...prevSummary, [day]: placeSummaries });
       } catch (error) {
-        setError('경로 검색에 실패했습니다.');
+        console.error('경로 검색 중 오류 발생:', error);
+        setError('경로 검색에 실패했습니다. 잠시 후 다시 시도해주세요.');
+        // 경로 검색 실패 시 빈 경로로 설정
+        setPaths((prev) => ({ ...prev, [day]: [] }));
       }
     },
     [map, routeCache, setRouteSummary],
@@ -302,6 +305,13 @@ export const usePlanMap = ({
       isMounted = false;
     };
   }, [dayPlaces, activeTab, map, getMarkersToShow, adjustMapView, searchRoute]);
+
+  // 에러 상태 초기화
+  useEffect(() => {
+    if (map) {
+      setError(null);
+    }
+  }, [map]);
 
   return {
     map,

--- a/src/types/plan.type.ts
+++ b/src/types/plan.type.ts
@@ -94,8 +94,6 @@ export type PlanHorizontalCardProps = {
   plan: Plan;
   /** 작성자 닉네임 (선택적) */
   nickname?: string;
-  /** 수정 핸들러 함수 */
-  onEdit?: (planId: number) => void;
   /** 삭제 핸들러 함수 */
   onDelete?: (planId: number) => void;
   /** 업데이트 핸들러 함수 */


### PR DESCRIPTION
## 📝 설명

<!-- 이 PR에서 무엇을 변경했는지 간단히 설명해주세요. -->

이 PR은 5월 2일 이슈 해결 우선순위 높은 것들을 진행하였습니다.

## 🔗 관련 이슈

<!-- 이 PR이 해결하는 이슈 번호를 적어주세요. -->

- #281 

## 🔍 변경 사항

<!-- 주요 변경 사항을 목록으로 작성해주세요. -->

- 바텀 시트가 열리면 Input이 있는 경우 자동으로 포커스가 가서 키보드가 자동으로 열리는 이슈
- 댓글을 단 이후 댓글창 자동으로 닫히는 현상 해결
- 수정하기 버튼 누르면 수정 페이지로 가지 않는 현상 해결
- 다른 사람 일정에 접속한 경우 상단 헤더(내 일정) 제거
- 아이폰에서 바텀시트가 작게 나오는 현상 해결
- 장소 카드 데이터가 수직 방향 가운데 정렬된 것을 위쪽 정렬되도록 수정
- 모바일 크기에서 일정 생성 버튼 추가
- 1-2-1 장소 추가시 경로 전체가 값이 나오지 않는 현상 해결
- 지도 사라지는 문제 해결(성산일출봉-우도 선택시 에러 발생), 일단 우도 데이터는 제거
- 장소 이미지 정사각형이 아닌 문제 해결
- 바텀시트 모든 디바이스에 대응하도록 수정
- 모바일 환경에서는 탭이 선택되어 있지 않아도 버튼 추가될수 있게 수정

## ✅ 체크리스트

<!-- PR을 제출하기 전에 확인해야 할 항목들을 체크해주세요. -->

- [x] 코드가 프로젝트의 스타일 가이드를 준수합니다.
- [x] 모든 테스트가 통과했습니다.

## ℹ️ 추가 정보

<!-- 리뷰어가 알아야 할 추가 정보나 참고 자료가 있다면 여기에 작성해주세요. -->
